### PR TITLE
Revamp Sync One-Line workflow with UI and ID tracking

### DIFF
--- a/AE PyDev.extension/AE pyTools.Tab/Developer.panel/develop2.stack/One-Line.pulldown/OneLine22.pushbutton/script.py
+++ b/AE PyDev.extension/AE pyTools.Tab/Developer.panel/develop2.stack/One-Line.pulldown/OneLine22.pushbutton/script.py
@@ -1,251 +1,29 @@
 # -*- coding: utf-8 -*-
-from pyrevit import script, revit, DB, forms
+from pyrevit import script, revit
+from CEDElectrical.Domain.one_line_tree import build_system_tree
 
 logger = script.get_logger()
-import csv
 
 
-# -------------------------------
-# Data Classes
-# -------------------------------
-
-class TreeBranch(object):
-    def __init__(self, system):
-        self.element_id = system.Id
-        self.base_eq = system.BaseEquipment
-        self.base_eq_id = self.base_eq.Id if self.base_eq else DB.ElementId.InvalidElementId
-        self.base_eq_name = DB.Element.Name.__get__(self.base_eq) if self.base_eq else "Unknown"
-        self.circuit_number = system.CircuitNumber
-        self.load_name = system.LoadName
-        self.system = system
-        self.is_feeder = False  # Will be set True if it connects two equipment nodes
-
-    def __str__(self):
-        return "- Circuit `{}` | Load `{}` | Feeder `{}`".format(
-            self.circuit_number, self.load_name, self.is_feeder
-        )
-
-    def to_dict(self, parent_node=None):
-        return {
-            "Parent Panel": parent_node.panel_name if parent_node else "",
-            "Parent ID": parent_node.element_id if parent_node else "",
-            "Circuit Number": self.circuit_number,
-            "Load Name": self.load_name,
-            "Branch ID": self.element_id,
-            "From Panel": self.base_eq_name,
-            "Feeder": self.is_feeder
-        }
-
-
-class TreeNode(object):
-    PART_TYPE_MAP = {
-        14: "Panelboard",
-        15: "Transformer",
-        16: "Switchboard",
-        17: "Other Panel",
-        18: "Equipment Switch"
-    }
-
-    def __init__(self, element):
-        self.element = element
-        self.element_id = element.Id
-        self.panel_name = DB.Element.Name.__get__(element)
-        self.upstream = []
-        self.downstream = []
-        self.is_leaf = False
-        self._part_type = self.get_family_part_type()
-        self.equipment_type = self.PART_TYPE_MAP.get(self._part_type, "Unknown")
-
-    def to_dict(self):
-        return {
-            "Panel Name": self.panel_name,
-            "Element ID": self.element_id,
-            "Equipment Type": self.equipment_type,
-            "Is Leaf": self.is_leaf,
-            "Upstream Count": len(self.upstream),
-            "Downstream Count": len(self.downstream)
-        }
-
-    def get_family_part_type(self):
-        if not self.element or not isinstance(self.element, DB.FamilyInstance):
-            return None
-
-        symbol = self.element.Symbol
-        if not symbol:
-            return None
-
-        family = symbol.Family
-        if not family:
-            return None
-
-        param = family.get_Parameter(DB.BuiltInParameter.FAMILY_CONTENT_PART_TYPE)
-        if param and param.HasValue:
-            return param.AsInteger()
-        return None
-
-    def collect_branches(self):
-        mep = self.element.MEPModel
-        if not mep:
-            return
-
-        all_systems = mep.GetElectricalSystems()
-        assigned = mep.GetAssignedElectricalSystems()
-        assigned_ids = set([sys.Id for sys in assigned]) if assigned else set()
-
-        for sys in all_systems:
-            br = TreeBranch(sys)
-            if br.base_eq_id == self.element_id:
-                self.downstream.append(br)
-            else:
-                self.upstream.append(br)
-
-        # Leaf check
-        self.is_leaf = not assigned or len(assigned) == 0
-
-
-class SystemTree(object):
-    def __init__(self):
-        self.nodes = {}  # {element_id: EquipmentNode}
-        self.root_nodes = []  # list of EquipmentNode
-
-    def add_node(self, node):
-        self.nodes[node.element_id] = node
-        if not node.upstream:
-            self.root_nodes.append(node)
-
-    def get_node(self, element_id):
-        return self.nodes.get(element_id)
-
-        # ... existing methods ...
-
-    def walk_all(self):
-        for root in self.root_nodes:
-            output.print_md("---\n### Root: **{}**".format(root.panel_name))
-            self.walk_tree(root, visited=set())
-
-    def walk_tree(self, node, visited=None, level=0):
-        if visited is None:
-            visited = set()
-
+def print_tree(output, tree):
+    def visitor(item, level):
         indent = "    " * level
-        output.print_md("{}**{}** (ID: {}) _({})_".format(
-            indent, node.panel_name, node.element_id, node.equipment_type
-        ))
-
-        visited.add(node.element_id)
-
-        for branch in node.downstream:
+        if hasattr(item, "circuit_number"):
             output.print_md("{}- Circuit `{}` | Load: `{}`".format(
-                "    " * (level + 1),
-                branch.circuit_number,
-                branch.load_name
+                indent, item.circuit_number, item.load_name
+            ))
+        else:
+            output.print_md("{}**{}** (ID: {}) _({})_".format(
+                indent, item.panel_name, item.element_id, item.equipment_type
             ))
 
-            system = branch.system
-            non_nodes = []  # For collecting leafs
-
-            if hasattr(system, "Elements"):
-                for e in list(system.Elements):
-                    if e.Category and int(e.Category.Id.IntegerValue) == int(
-                            DB.BuiltInCategory.OST_ElectricalEquipment):
-                        if e.Id not in visited:
-                            branch.is_feeder = True
-                            child_node = self.nodes.get(e.Id)
-                            if child_node:
-                                self.walk_tree(child_node, visited, level + 2)
-                    else:
-                        non_nodes.append(e)
-
-            # LEAF SUMMARY
-            leaf_counter = {}
-            for e in non_nodes:
-                cat = e.Category
-                if not cat:
-                    continue
-                cat_name = cat.Name
-                leaf_counter[cat_name] = leaf_counter.get(cat_name, 0) + 1
-
-            for cat_name, count in leaf_counter.items():
-                output.print_md("{}- `{}` leaf(s): **{}**".format(
-                    "    " * (level + 2),
-                    cat_name,
-                    count
-                ))
-
-    def to_list(self):
-        data = []
-
-        for node in self.nodes.values():
-            node_record = node.to_dict()
-            for branch in node.downstream:
-                branch_record = branch.to_dict(parent_node=node)
-                combined = dict(node_record)
-                combined.update(branch_record)
-                data.append(combined)
-
-        return data
-
-    def export_to_csv(self, filepath):
-        data = self.to_list()
-        if not data:
-            logger.warning("No data to export.")
-            return
-
-        fieldnames = list(data[0].keys())
-
-        try:
-            with open(filepath, 'w') as f:
-                writer = csv.DictWriter(f, fieldnames=fieldnames)
-                writer.writeheader()
-                writer.writerows(data)
-
-            logger.info("Exported tree to CSV: {}".format(filepath))
-        except Exception as e:
-            logger.error("Failed to export CSV: {}".format(str(e)))
-
-    def _request_path(self):
-        path = forms.save_file(file_ext='csv',default_name="system_tree_export")
-        return path
+    for root in tree.root_nodes:
+        output.print_md("---\n### Root: **{}**".format(root.panel_name))
+        tree.walk_tree(root, visitor)
 
 
-# ----------------------------
-# Build the Equipment Map
-# ----------------------------
-
-def get_all_equipment_nodes(doc):
-    nodes = {}
-    collector = DB.FilteredElementCollector(doc) \
-        .OfCategory(DB.BuiltInCategory.OST_ElectricalEquipment) \
-        .WhereElementIsNotElementType()
-
-    for equip in collector:
-        node = TreeNode(equip)
-        node.collect_branches()
-        nodes[equip.Id] = node
-    return nodes
-
-
-# ----------------------------
-# Recursively Build the Tree
-# ----------------------------
-
-
-# -------------------------------
-# Main Execution
-# -------------------------------
 if __name__ == "__main__":
-    doc = revit.doc
-    uidoc = revit.uidoc
     output = script.get_output()
-    logger = script.get_logger()
     output.close_others()
-
-    # Build node map
-    equipment_map = get_all_equipment_nodes(doc)
-
-    # Create and populate tree
-    tree = SystemTree()
-    for node in equipment_map.values():
-        tree.add_node(node)
-
-    tree.walk_all()
+    tree = build_system_tree(revit.doc)
+    print_tree(output, tree)

--- a/AE pyTools.extension/AE pyTools.Tab/Electrical.panel/Circuits2.stack/Sync One Line.pushbutton/script.py
+++ b/AE pyTools.extension/AE pyTools.Tab/Electrical.panel/Circuits2.stack/Sync One Line.pushbutton/script.py
@@ -60,7 +60,14 @@ def set_selection(ids):
 
 
 def get_circuit_sort_key(branch):
-    val = branch.circuit_number or ""
+    val = None
+    try:
+        val = branch.CircuitNumber
+    except Exception:
+        try:
+            val = branch.circuit_number
+        except Exception:
+            val = ""
     try:
         return int(val)
     except Exception:

--- a/AE pyTools.extension/AE pyTools.Tab/Electrical.panel/Circuits2.stack/Sync One Line.pushbutton/script.py
+++ b/AE pyTools.extension/AE pyTools.Tab/Electrical.panel/Circuits2.stack/Sync One Line.pushbutton/script.py
@@ -1,490 +1,112 @@
 # -*- coding: utf-8 -*-
-# IRONPYTHON 2.7 COMPATIBLE (no f-strings, no .format usage)
-from pyrevit import revit, DB, script
+import os
+from pyrevit import revit, DB, script, forms
+from CEDElectrical.Domain.one_line_sync import OneLineSyncService
+import UIClasses.SyncOneLineWindow as sync_ui
+from UIClasses.SyncOneLineWindow import SyncOneLineWindow, SyncOneLineListItem, status_symbol
 
 logger = script.get_logger()
 
-# ----------------------------------------------------------------------
-# SOURCE: The circuit/panel data is read from Revit elements:
-#   Circuits (ElectricalSystem) -> read built-in param: RBS_ELEC_CIRCUIT_PANEL_PARAM, RBS_ELEC_CIRCUIT_NUMBER, etc.
-#   Panels  (ElectricalEquipment) -> read built-in param: RBS_ELEC_PANEL_NAME, etc.
-#
-# DESTINATION: The detail items hold custom "which circuit/panel?" params:
-#   e.g. "CKT_Panel_CEDT", "CKT_Circuit Number_CEDT", "Panel Name_CEDT"
-# so we can figure out which circuit/panel data to copy in.
-#
-# Then we apply the circuit/panel values into the detail items' "CKT_Rating_CED" etc.
-
-# These are the custom param names on detail items that hold the "which circuit/panel?" data:
-DETAIL_PARAM_CKT_PANEL = "CKT_Panel_CEDT"
-DETAIL_PARAM_CKT_NUMBER = "CKT_Circuit Number_CEDT"
-DETAIL_PARAM_PANEL_NAME = "Panel Name_CEDT"
-DETAIL_PARAM_SC_PANEL_ID = "SC_Panel ElementId"
-DETAIL_PARAM_SC_CIRCUIT_ID = "SC_Circuit ElementId"
-
-DEVICE_CATEGORY_IDS = [
-    DB.ElementId(DB.BuiltInCategory.OST_ElectricalFixtures),
-    DB.ElementId(DB.BuiltInCategory.OST_ElectricalEquipment),
-    DB.ElementId(DB.BuiltInCategory.OST_LightingFixtures),
-    DB.ElementId(DB.BuiltInCategory.OST_DataDevices)
-]
-
-# Circuit built-in param -> we store them in a dictionary so we can quickly read
-# Then we map them to detail param names that we’ll set.
-# Key here is "DetailParamName" : "BuiltInParamOnCircuit"
-CIRCUIT_VALUE_MAP = {
-    "x VD Schedule": "x VD Schedule",
-    "Circuit Tree Sort_CED": "Circuit Tree Sort_CED",
-    "CKT_Circuit Type_CEDT": "CKT_Circuit Type_CEDT",
-    "CKT_Panel_CEDT": DB.BuiltInParameter.RBS_ELEC_CIRCUIT_PANEL_PARAM,
-    "CKT_Circuit Number_CEDT": DB.BuiltInParameter.RBS_ELEC_CIRCUIT_NUMBER,
-    "CKT_Load Name_CEDT": DB.BuiltInParameter.RBS_ELEC_CIRCUIT_NAME,
-    "CKT_Rating_CED": DB.BuiltInParameter.RBS_ELEC_CIRCUIT_RATING_PARAM,
-    "CKT_Frame_CED": DB.BuiltInParameter.RBS_ELEC_CIRCUIT_FRAME_PARAM,
-    "CKT_Schedule Notes_CEDT": DB.BuiltInParameter.RBS_ELEC_CIRCUIT_NOTES_PARAM,
-    "CKT_Length_CED": DB.BuiltInParameter.RBS_ELEC_CIRCUIT_LENGTH_PARAM,
-    "Number of Poles_CED": DB.BuiltInParameter.RBS_ELEC_NUMBER_OF_POLES,
-    "Voltage_CED": DB.BuiltInParameter.RBS_ELEC_VOLTAGE,
-    "Wire Material_CEDT": "Wire Material_CEDT",
-    "Wire Insulation_CEDT": "Wire Insulation_CEDT",
-    "Wire Temparature Rating_CEDT": "Wire Temparature Rating_CEDT",
-    "Wire Size_CEDT": "Wire Size_CEDT",
-    "Conduit and Wire Size_CEDT": "Conduit and Wire Size_CEDT",
-    "Conduit Type_CEDT": "Conduit Type_CEDT",
-    "Conduit Size_CEDT": "Conduit Size_CEDT",
-    "Conduit Fill Percentage_CED": "Conduit Fill Percentage_CED",
-    "Voltage Drop Percentage_CED": "Voltage Drop Percentage_CED",
-    "Circuit Load Current_CED": "Circuit Load Current_CED"
-}
-
-# Panel built-in param -> detail param name map
-PANEL_VALUE_MAP = {
-    "Panel Name_CEDT": DB.BuiltInParameter.RBS_ELEC_PANEL_NAME,
-    "Mains Rating_CED": "Mains Rating_CED",
-    "Mains Type_CEDT": "Mains Type_CEDT",
-    "Phase_CED": "Phase_CED",
-    "Main Breaker Rating_CED": DB.BuiltInParameter.RBS_ELEC_PANEL_MCB_RATING_PARAM,
-    "Short Circuit Rating_CEDT": DB.BuiltInParameter.RBS_ELEC_SHORT_CIRCUIT_RATING,
-    "Mounting_CEDT": DB.BuiltInParameter.RBS_ELEC_MOUNTING,
-    "Panel Modifications_CEDT": DB.BuiltInParameter.RBS_ELEC_MODIFICATIONS,
-    "Distribution System_CEDR": DB.BuiltInParameter.RBS_FAMILY_CONTENT_DISTRIBUTION_SYSTEM,
-    "Secondary Distribution System_CEDR": DB.BuiltInParameter.RBS_FAMILY_CONTENT_SECONDARY_DISTRIBSYS,
-    "Total Connected Load_CEDR": DB.BuiltInParameter.RBS_ELEC_PANEL_TOTALLOAD_PARAM,
-    "Total Demand Load_CEDR": DB.BuiltInParameter.RBS_ELEC_PANEL_TOTAL_DEMAND_CURRENT_PARAM,
-    "Total Connected Current_CEDR": DB.BuiltInParameter.RBS_ELEC_PANEL_TOTAL_CONNECTED_CURRENT_PARAM,
-    "Total Demand Current_CEDR": DB.BuiltInParameter.RBS_ELEC_PANEL_TOTAL_DEMAND_CURRENT_PARAM,
-    "Max Number of Single Pole Breakers_CED": DB.BuiltInParameter.RBS_ELEC_MAX_POLE_BREAKERS,
-    "Max Number of Circuits_CED": DB.BuiltInParameter.RBS_ELEC_NUMBER_OF_CIRCUITS,
-    "Transformer Rating_CEDT": "Transformer Rating_CEDT",
-    "Transformer Rating_CED": "Transformer Rating_CEDT",
-    "Transformer Primary Description_CEDT": "Transformer Primary Description_CEDT",
-    "Transformer Secondary Description_CEDT": "Transformer Secondary Description_CEDT",
-    "Transformer %Z_CED": "Transformer %Z_CED",
-    "Panel Feed_CEDT": DB.BuiltInParameter.RBS_ELEC_PANEL_FEED_PARAM,
-}
+XAML_PATH = os.path.join(os.path.dirname(sync_ui.__file__), "SyncOneLineWindow.xaml")
 
 
-def get_model_param_value(elem, param_key, allow_type_fallback=True):
-    """
-    Reads either a BuiltInParameter or a shared parameter (by name).
-    Checks instance first, then type if not found and allowed.
-    Returns string/int/double or None.
-    """
-    param = None
-
-    # Try instance-level parameter
-    if isinstance(param_key, DB.BuiltInParameter):
-        param = elem.get_Parameter(param_key)
-    elif isinstance(param_key, str):
-        param = elem.LookupParameter(param_key)
-    else:
-        logger.debug("get_model_param_value: Invalid param key type: " + str(param_key))
-        return None
-
-    # Try type-level parameter if instance param is missing and fallback is allowed
-    if not param and allow_type_fallback:
+def get_element_label(assoc):
+    elem = assoc.model_elem
+    if assoc.kind == "circuit":
         try:
-            type_elem = elem.Document.GetElement(elem.GetTypeId())
-            if type_elem:
-                if isinstance(param_key, DB.BuiltInParameter):
-                    param = type_elem.get_Parameter(param_key)
-                elif isinstance(param_key, str):
-                    param = type_elem.LookupParameter(param_key)
-        except Exception as e:
-            logger.debug("get_model_param_value: Error accessing type element for " + str(elem.Id) + ": " + str(e))
-
-    # Final check
-    if not param:
-        logger.debug("get_model_param_value: Param '{}' not found on element {}".format(param_key, elem.Id))
-        return None
-
-    st = param.StorageType
-    if st == DB.StorageType.String:
-        return param.AsString()
-    elif st == DB.StorageType.Integer:
-        return param.AsInteger()
-    elif st == DB.StorageType.Double:
-        return param.AsDouble()
-    elif st == DB.StorageType.ElementId:
-        return param.AsValueString()
-
-    return None
-
-
-def get_detail_param_value(elem, param_name):
-    """
-    Read a string/int/double from the detail item’s custom param param_name. Return None if not found or empty.
-    """
-    p = elem.LookupParameter(param_name)
-    if not p:
-        logger.debug("    get_detail_param_value: Param '" + param_name + "' not found on detail item " + str(elem.Id))
-        return None
-
-    st = p.StorageType
-    if st == DB.StorageType.String:
-        return p.AsString()
-    elif st == DB.StorageType.Integer:
-        return p.AsInteger()
-    elif st == DB.StorageType.Double:
-        return p.AsDouble()
-    elif st == DB.StorageType.ElementId:
-        return p.AsValueString()
-    return None
-
-
-def set_detail_param_value(elem, param_name, new_value):
-    """
-    Sets the detail item’s param_name to str(new_value).
-    """
-    p = elem.LookupParameter(param_name)
-    if not p:
-        logger.debug("      set_detail_param_value: Param '" + param_name + "' not found on " + str(elem.Id))
-        return
-    if p.IsReadOnly:
-        logger.debug("      set_detail_param_value: Param '" + param_name + "' is read-only on " + str(elem.Id))
-        return
-    try:
-        if new_value is None:
-            new_value = ""
-        p.Set(new_value)
-        logger.debug(
-            "      set_detail_param_value: Set '" + param_name + "' to '" + str(new_value) + "' on " + str(elem.Id))
-    except:
-        logger.debug("      set_detail_param_value: FAILED setting '" + param_name + "' on " + str(elem.Id))
-
-
-def is_not_in_group(element):
-    return element.GroupId == DB.ElementId.InvalidElementId
-
-
-def element_has_sc_params(elem):
-    """
-    Returns True if the element has any parameters whose names start with 'SC_'.
-    Used so we only flag missing references on elements expecting SC_ data.
-    """
-    try:
-        for param in elem.Parameters:
-            try:
-                definition = param.Definition
-                if definition:
-                    pname = definition.Name
-                    if pname and pname.startswith("SC_"):
-                        return True
-            except Exception as exc:
-                logger.debug("element_has_sc_params: Failed checking param on {}: {}".format(elem.Id, exc))
-                continue
-    except Exception as exc:
-        logger.debug("element_has_sc_params: Could not iterate params on {}: {}".format(elem.Id, exc))
-    return False
-
-
-def describe_detail_item(doc, detail_elem):
-    """
-    Returns (name, owner_view_name) tuple for reporting back to the user.
-    """
-    try:
-        name = detail_elem.Name
-    except Exception:
-        name = ""
-
-    view_name = ""
-    try:
-        owner_view_id = getattr(detail_elem, "OwnerViewId", None)
-        if owner_view_id and owner_view_id != DB.ElementId.InvalidElementId:
-            owner_view = doc.GetElement(owner_view_id)
-            if owner_view:
-                view_name = owner_view.Name
-    except Exception as exc:
-        logger.debug("describe_detail_item: Failed getting view for {}: {}".format(detail_elem.Id, exc))
-
-    return name, view_name
-
-
-def element_category_in_targets(elem):
-    """
-    Returns True if the element's category is one of the device categories we want to update.
-    """
-    cat = elem.Category
-    if not cat:
-        return False
-    for target_cat_id in DEVICE_CATEGORY_IDS:
-        if cat.Id == target_cat_id:
-            return True
-    return False
-
-
-def update_devices_with_sc_ids(circuit):
-    """
-    Writes SC element ids to family instances connected to the provided circuit.
-    """
-    if not circuit:
-        return 0
-    panel_elem = None
-    try:
-        panel_elem = circuit.BaseEquipment
-    except Exception as panel_exc:
-        logger.debug("update_devices_with_sc_ids: Failed to get panel for {}: {}".format(circuit.Id, panel_exc))
-
-    panel_id_str = ""
-    if panel_elem:
-        try:
-            panel_id_str = str(panel_elem.Id.IntegerValue)
+            panel = elem.BaseEquipment
+            panel_name = panel.Name if panel else ""
         except Exception:
-            panel_id_str = ""
+            panel_name = ""
+        try:
+            cnum = elem.CircuitNumber
+        except Exception:
+            cnum = ""
+        return "{} {}".format(panel_name, cnum).strip()
+    try:
+        return elem.Name
+    except Exception:
+        return "Element {}".format(elem.Id.IntegerValue)
 
-    circuit_id_str = str(circuit.Id.IntegerValue)
-    updated = 0
-    for elem in circuit.Elements:
-        if not isinstance(elem, DB.FamilyInstance):
-            continue
-        if not element_category_in_targets(elem):
-            continue
-        set_detail_param_value(elem, DETAIL_PARAM_SC_CIRCUIT_ID, circuit_id_str)
-        if panel_id_str:
-            set_detail_param_value(elem, DETAIL_PARAM_SC_PANEL_ID, panel_id_str)
-        updated += 1
-    return updated
+
+def build_list_items(associations):
+    items = []
+    for assoc in associations:
+        label = get_element_label(assoc)
+        kind_label = assoc.kind.capitalize()
+        display = "[{}] {} (Id {})".format(kind_label, label, assoc.model_elem.Id.IntegerValue)
+        symbol, brush = status_symbol(assoc.status)
+        items.append(SyncOneLineListItem(assoc, display, symbol, brush))
+    return items
+
+
+def ensure_detail_view(view):
+    if view.ViewType in [DB.ViewType.DraftingView, DB.ViewType.Detail, DB.ViewType.FloorPlan,
+                         DB.ViewType.CeilingPlan, DB.ViewType.Section, DB.ViewType.Elevation]:
+        return True
+    return False
 
 
 def main():
     doc = revit.doc
-    logger.info("=== Syncing Circuit/Panel param values to detail items ===")
+    view = revit.active_view
 
-    # 1) Build circuit dictionary keyed by (panel_name, circuit_number)
-    circuit_map = {}
-    circuit_map_by_id = {}
-    logger.debug("Collecting circuits...")
+    service = OneLineSyncService(doc)
+    associations = service.build_associations()
 
-    # design option filter
-    option_filter = DB.ElementDesignOptionFilter(DB.ElementId.InvalidElementId)
+    if not associations:
+        forms.alert("No circuits, panels, or devices found.")
+        return
 
-    ckt_collector = DB.FilteredElementCollector(doc) \
-        .OfClass(DB.Electrical.ElectricalSystem) \
-        .WherePasses(option_filter) \
-        .ToElements()
+    list_items = build_list_items(associations)
 
-    for ckt in ckt_collector:
-        pval = get_model_param_value(ckt, DB.BuiltInParameter.RBS_ELEC_CIRCUIT_PANEL_PARAM)
-        cnum = get_model_param_value(ckt, DB.BuiltInParameter.RBS_ELEC_CIRCUIT_NUMBER)
-        if pval and cnum:
-            key = (str(pval), str(cnum))
-            # gather all relevant param values into a sub-dict
-            cdata = {}
-            for detail_param_name, bip in CIRCUIT_VALUE_MAP.items():
-                cdata[detail_param_name] = get_model_param_value(ckt, bip)
-            cdata[DETAIL_PARAM_SC_CIRCUIT_ID] = str(ckt.Id.IntegerValue)
-            circuit_map[key] = cdata
-            circuit_map_by_id[str(ckt.Id.IntegerValue)] = cdata
-            logger.debug("  Circuit " + str(ckt.Id) + " => key " + str(key) + " stored")
-        else:
-            logger.debug("  Circuit " + str(ckt.Id) + " missing panel or circuit # => skipping")
+    detail_symbols = service.collect_detail_symbols()
+    tag_symbols = service.collect_tag_symbols()
 
-    # 2) Build panel dictionary keyed by panel_name
-    panel_map = {}
-    panel_map_by_id = {}
-    logger.debug("Collecting panels...")
+    window = SyncOneLineWindow(XAML_PATH, list_items, detail_symbols, tag_symbols)
+    window.ShowDialog()
 
-    pnl_collector = DB.FilteredElementCollector(doc) \
-        .OfCategory(DB.BuiltInCategory.OST_ElectricalEquipment) \
-        .WhereElementIsNotElementType() \
-        .WherePasses(option_filter) \
-        .ToElements()
+    action = window.requested_action
+    if not action:
+        return
 
-    for pnl in pnl_collector:
+    selected_associations = window.get_selected_associations()
+    if not selected_associations:
+        forms.alert("Please select at least one element.")
+        return
 
-        pname = get_model_param_value(pnl, DB.BuiltInParameter.RBS_ELEC_PANEL_NAME)
-        if pname:
-            pdata = {}
-            for detail_param_name, bip in PANEL_VALUE_MAP.items():
-                pdata[detail_param_name] = get_model_param_value(pnl, bip)
-            pdata[DETAIL_PARAM_SC_PANEL_ID] = str(pnl.Id.IntegerValue)
-            panel_map[str(pname)] = pdata
-            panel_map_by_id[str(pnl.Id.IntegerValue)] = pdata
-            logger.debug("  Panel " + str(pnl.Id) + " => name '" + pname + "' stored")
-        else:
-            logger.debug("  Panel " + str(pnl.Id) + " has no name => skipping")
+    if action == "create":
+        if not ensure_detail_view(view):
+            forms.alert("Active view must support detail items.")
+            return
 
-    # 3) Collect detail items
-    detail_item_collector = DB.FilteredElementCollector(doc) \
-        .OfCategory(DB.BuiltInCategory.OST_DetailComponents) \
-        .WhereElementIsNotElementType() \
-        .WherePasses(option_filter) \
-        .ToElements()
+        detail_symbol = window.get_selected_detail_symbol()
+        if not detail_symbol:
+            forms.alert("Select a detail item family and type before creating.")
+            return
 
-    detail_items = [
-        el for el in detail_item_collector
-        if is_not_in_group(el)]
-    logger.debug("Collected " + str(len(detail_items)) + " detail item(s).")
+        tag_symbol = window.get_selected_tag_symbol()
+        panel_associations = [assoc for assoc in selected_associations if assoc.kind == "panel"]
+        if not panel_associations:
+            forms.alert("Select panel equipment to create detail items.")
+            return
 
-    t = DB.Transaction(doc, "Sync Circuits/Panels to Detail Items")
-    t.Start()
-    update_count = 0
-    sc_device_update_count = 0
-    sc_missing_reference_records = []
+        t = DB.Transaction(doc, "Create One-Line Detail Items")
+        t.Start()
+        created = service.create_detail_items(panel_associations, detail_symbol, view, tag_symbol)
+        updated = service.sync_associations(created)
+        t.Commit()
 
-    for ckt in ckt_collector:
-        sc_device_update_count += update_devices_with_sc_ids(ckt)
+        forms.alert("Created {} detail item(s) and synced {} panel(s).".format(len(created), updated))
+        return
 
-    for ditem in detail_items:
-        logger.debug("Detail item " + str(ditem.Id) + ":")
-        # read which circuit/panel from the detail item’s custom parameters
-        cpanel_val = get_detail_param_value(ditem, DETAIL_PARAM_CKT_PANEL)
-        cnum_val = get_detail_param_value(ditem, DETAIL_PARAM_CKT_NUMBER)
-        pname_val = get_detail_param_value(ditem, DETAIL_PARAM_PANEL_NAME)
+    if action == "sync":
+        t = DB.Transaction(doc, "Sync One-Line Detail Items")
+        t.Start()
+        updated = service.sync_associations(selected_associations)
+        t.Commit()
 
-        logger.debug("    cpanel_val='" + str(cpanel_val) + "' cnum_val='" + str(cnum_val) + "' pname_val='" + str(
-            pname_val) + "'")
-        changed = False
-        missing_contexts = []
-        sc_circuit_id_val = get_detail_param_value(ditem, DETAIL_PARAM_SC_CIRCUIT_ID)
-        sc_panel_id_val = get_detail_param_value(ditem, DETAIL_PARAM_SC_PANEL_ID)
-
-        circuit_id_lookup = None
-        if sc_circuit_id_val not in (None, "", 0):
-            circuit_id_lookup = str(sc_circuit_id_val).strip()
-            if not circuit_id_lookup or circuit_id_lookup == "0":
-                circuit_id_lookup = None
-
-        panel_id_lookup = None
-        if sc_panel_id_val not in (None, "", 0):
-            panel_id_lookup = str(sc_panel_id_val).strip()
-            if not panel_id_lookup or panel_id_lookup == "0":
-                panel_id_lookup = None
-
-        has_circuit_reference = bool(circuit_id_lookup) or (cpanel_val and cnum_val)
-        if not has_circuit_reference:
-            missing_fields = []
-            if not circuit_id_lookup:
-                missing_fields.append(DETAIL_PARAM_SC_CIRCUIT_ID)
-            if not cpanel_val:
-                missing_fields.append(DETAIL_PARAM_CKT_PANEL)
-            if not cnum_val:
-                missing_fields.append(DETAIL_PARAM_CKT_NUMBER)
-            missing_contexts.append({
-                "context": "Circuit reference",
-                "fields": missing_fields
-            })
-
-        has_panel_reference = bool(panel_id_lookup) or bool(pname_val) or bool(cpanel_val)
-        if not has_panel_reference:
-            missing_fields = []
-            if not panel_id_lookup:
-                missing_fields.append(DETAIL_PARAM_SC_PANEL_ID)
-            if not pname_val:
-                missing_fields.append(DETAIL_PARAM_PANEL_NAME)
-            if not cpanel_val:
-                missing_fields.append(DETAIL_PARAM_CKT_PANEL)
-            missing_contexts.append({
-                "context": "Panel reference",
-                "fields": missing_fields
-            })
-
-        # Resolve circuit data by ElementId first, then by (panel, number)
-        cdict = None
-        if circuit_id_lookup:
-            if circuit_id_lookup in circuit_map_by_id:
-                cdict = circuit_map_by_id[circuit_id_lookup]
-                logger.debug("    Found circuit data for ElementId " + circuit_id_lookup)
-            else:
-                logger.debug("    No circuit data for ElementId " + circuit_id_lookup)
-        if not cdict and cpanel_val and cnum_val:
-            ckey = (str(cpanel_val), str(cnum_val))
-            if ckey in circuit_map:
-                cdict = circuit_map[ckey]
-                logger.debug("    Found circuit data for key " + str(ckey))
-            else:
-                logger.debug("    No circuit data in circuit_map for key " + str(ckey))
-
-        if cdict:
-            for detail_pname, ckt_val in cdict.items():
-                set_detail_param_value(ditem, detail_pname, ckt_val)
-            changed = True
-
-        # Resolve panel data: ElementId -> Panel Name -> CKT_Panel fallback
-        pdict = None
-        if panel_id_lookup:
-            if panel_id_lookup in panel_map_by_id:
-                pdict = panel_map_by_id[panel_id_lookup]
-                logger.debug("    Found panel data for ElementId " + panel_id_lookup)
-            else:
-                logger.debug("    No panel data for ElementId " + panel_id_lookup)
-        if not pdict and pname_val:
-            panel_lookup_name = str(pname_val)
-            if panel_lookup_name in panel_map:
-                pdict = panel_map[panel_lookup_name]
-                logger.debug("    Found panel data for '" + panel_lookup_name + "' (from " + DETAIL_PARAM_PANEL_NAME + ")")
-            else:
-                logger.debug("    No panel data in panel_map for '" + panel_lookup_name + "' (from " + DETAIL_PARAM_PANEL_NAME + ")")
-        if not pdict and cpanel_val:
-            panel_lookup_name = str(cpanel_val)
-            if not pname_val:
-                logger.debug("    Panel reference missing '" + DETAIL_PARAM_PANEL_NAME + "' so inferring from '" + DETAIL_PARAM_CKT_PANEL + "' value '" + panel_lookup_name + "'")
-            else:
-                logger.debug("    Panel name '" + str(pname_val) + "' not found; trying '" + DETAIL_PARAM_CKT_PANEL + "' value '" + panel_lookup_name + "' instead")
-            if panel_lookup_name in panel_map:
-                pdict = panel_map[panel_lookup_name]
-                logger.debug("    Found panel data for '" + panel_lookup_name + "' (from " + DETAIL_PARAM_CKT_PANEL + ")")
-            else:
-                logger.debug("    No panel data in panel_map for '" + panel_lookup_name + "' (from " + DETAIL_PARAM_CKT_PANEL + ")")
-
-        if pdict:
-            for detail_pname, pval in pdict.items():
-                set_detail_param_value(ditem, detail_pname, pval)
-            changed = True
-
-        if changed:
-            logger.debug("    => Updated this detail item.")
-            update_count += 1
-        else:
-            logger.debug("    => No changes for this detail item.")
-
-        if missing_contexts and element_has_sc_params(ditem):
-            name, view_name = describe_detail_item(doc, ditem)
-            sc_missing_reference_records.append({
-                "id": ditem.Id.IntegerValue,
-                "name": name,
-                "view": view_name,
-                "contexts": missing_contexts
-            })
-
-    t.Commit()
-    logger.info(
-        "Sync finished. Updated " + str(update_count) + " detail item(s) and propagated SC ids to " + str(
-            sc_device_update_count) + " device(s).")
-
-    if sc_missing_reference_records:
-        output = script.get_output()
-        output.close_others()
-        output.print_md("## SC Detail Items Skipped")
-        for record in sc_missing_reference_records:
-            label_name = record["name"] if record["name"] else "(Unnamed Detail Item)"
-            base_label = "`{}` (Id {})".format(label_name, record["id"])
-            if record["view"]:
-                base_label += " in view '{}'".format(record["view"])
-            context_msgs = []
-            for ctx in record["contexts"]:
-                context_msgs.append(ctx["context"] + " missing: " + ", ".join(ctx["fields"]))
-            output.print_md("* {} – {}".format(base_label, "; ".join(context_msgs)))
+        forms.alert("Synced {} element(s).".format(updated))
 
 
 if __name__ == "__main__":

--- a/AE pyTools.extension/AE pyTools.Tab/Electrical.panel/Circuits2.stack/Sync One Line.pushbutton/script.py
+++ b/AE pyTools.extension/AE pyTools.Tab/Electrical.panel/Circuits2.stack/Sync One Line.pushbutton/script.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 import os
 from pyrevit import revit, DB, script, forms
+from Autodesk.Revit.Exceptions import OperationCanceledException
 from CEDElectrical.Domain.one_line_sync import OneLineSyncService
+from CEDElectrical.Domain.one_line_tree import build_system_tree
 import UIClasses.SyncOneLineWindow as sync_ui
 from UIClasses.SyncOneLineWindow import SyncOneLineWindow, SyncOneLineListItem, status_symbol
 
@@ -29,15 +31,74 @@ def get_element_label(assoc):
         return "Element {}".format(elem.Id.IntegerValue)
 
 
-def build_list_items(associations):
+def build_list_items(associations, tree_order):
     items = []
+    assoc_to_item = {}
     for assoc in associations:
         label = get_element_label(assoc)
         kind_label = assoc.kind.capitalize()
         display = "[{}] {} (Id {})".format(kind_label, label, assoc.model_elem.Id.IntegerValue)
         symbol, brush = status_symbol(assoc.status)
-        items.append(SyncOneLineListItem(assoc, display, symbol, brush))
+        item = SyncOneLineListItem(assoc, display, display, symbol, brush)
+        items.append(item)
+        assoc_to_item[assoc] = item
+
+    for assoc, indent in tree_order:
+        if assoc in assoc_to_item:
+            base_text = assoc_to_item[assoc].base_text
+            assoc_to_item[assoc].tree_text = "{}{}".format("    " * indent, base_text)
+
     return items
+
+
+def get_circuit_sort_key(branch):
+    val = branch.circuit_number or ""
+    try:
+        return int(val)
+    except Exception:
+        return str(val)
+
+
+def build_tree_order(associations, doc):
+    assoc_by_id = {}
+    for assoc in associations:
+        assoc_by_id[assoc.model_elem.Id.IntegerValue] = assoc
+
+    ordered = []
+    visited = set()
+    tree = build_system_tree(doc)
+
+    def add_assoc(assoc, indent):
+        if not assoc:
+            return
+        assoc_id = assoc.model_elem.Id.IntegerValue
+        if assoc_id in visited:
+            return
+        ordered.append((assoc, indent))
+        visited.add(assoc_id)
+
+    def walk_node(node, indent):
+        add_assoc(assoc_by_id.get(node.element_id.IntegerValue), indent)
+        for branch in sorted(node.downstream, key=get_circuit_sort_key):
+            add_assoc(assoc_by_id.get(branch.element_id.IntegerValue), indent + 1)
+            system = branch.system
+            if hasattr(system, "Elements"):
+                for elem in list(system.Elements):
+                    if elem.Category and int(elem.Category.Id.IntegerValue) == int(DB.BuiltInCategory.OST_ElectricalEquipment):
+                        child_node = tree.get_node(elem.Id)
+                        if child_node:
+                            walk_node(child_node, indent + 2)
+                    else:
+                        add_assoc(assoc_by_id.get(elem.Id.IntegerValue), indent + 2)
+
+    for root in sorted(tree.root_nodes, key=lambda n: n.panel_name or ""):
+        walk_node(root, 0)
+
+    for assoc in associations:
+        if assoc.model_elem.Id.IntegerValue not in visited:
+            ordered.append((assoc, 0))
+
+    return ordered
 
 
 def ensure_detail_view(view):
@@ -45,6 +106,14 @@ def ensure_detail_view(view):
                          DB.ViewType.CeilingPlan, DB.ViewType.Section, DB.ViewType.Elevation]:
         return True
     return False
+
+
+def refresh_statuses(service, items):
+    for item in items:
+        item.association.status = service.compute_status(item.association)
+        symbol, brush = status_symbol(item.association.status)
+        item.status_symbol = symbol
+        item.status_brush = brush
 
 
 def main():
@@ -58,26 +127,40 @@ def main():
         forms.alert("No circuits, panels, or devices found.")
         return
 
-    list_items = build_list_items(associations)
+    tree_order = build_tree_order(associations, doc)
+    list_items = build_list_items(associations, tree_order)
 
     detail_symbols = service.collect_detail_symbols()
     tag_symbols = service.collect_tag_symbols()
 
-    window = SyncOneLineWindow(XAML_PATH, list_items, detail_symbols, tag_symbols)
-    window.ShowDialog()
+    def on_sync():
+        selected_associations = window.get_selected_associations()
+        if not selected_associations:
+            forms.alert("Please select at least one element.")
+            return
 
-    action = window.requested_action
-    if not action:
-        return
+        t = DB.Transaction(doc, "Sync One-Line Detail Items")
+        t.Start()
+        updated = service.sync_associations(selected_associations)
+        t.Commit()
 
-    selected_associations = window.get_selected_associations()
-    if not selected_associations:
-        forms.alert("Please select at least one element.")
-        return
+        refresh_statuses(service, list_items)
+        window.refresh_items()
 
-    if action == "create":
+        warnings = service.get_link_warnings(selected_associations)
+        if warnings:
+            forms.alert("Sync completed with warnings:\n\n- " + "\n- ".join(warnings))
+        else:
+            forms.alert("Synced {} element(s).".format(updated))
+
+    def on_create():
         if not ensure_detail_view(view):
             forms.alert("Active view must support detail items.")
+            return
+
+        selected_associations = window.get_selected_associations()
+        if not selected_associations:
+            forms.alert("Please select at least one element.")
             return
 
         detail_symbol = window.get_selected_detail_symbol()
@@ -86,27 +169,40 @@ def main():
             return
 
         tag_symbol = window.get_selected_tag_symbol()
-        panel_associations = [assoc for assoc in selected_associations if assoc.kind == "panel"]
-        if not panel_associations:
-            forms.alert("Select panel equipment to create detail items.")
+
+        try:
+            window.Hide()
+            base_point = revit.uidoc.Selection.PickPoint("Pick insertion point for detail items")
+        except OperationCanceledException:
+            window.Show()
+            return
+        finally:
+            window.Show()
+
+        associations_to_create = [assoc for assoc in selected_associations if assoc.detail_elem is None]
+        if not associations_to_create:
+            forms.alert("Selected elements already have detail items.")
             return
 
         t = DB.Transaction(doc, "Create One-Line Detail Items")
         t.Start()
-        created = service.create_detail_items(panel_associations, detail_symbol, view, tag_symbol)
+        created = service.create_detail_items(associations_to_create, detail_symbol, view, base_point, tag_symbol)
         updated = service.sync_associations(created)
         t.Commit()
 
-        forms.alert("Created {} detail item(s) and synced {} panel(s).".format(len(created), updated))
-        return
+        refresh_statuses(service, list_items)
+        window.refresh_items()
 
-    if action == "sync":
-        t = DB.Transaction(doc, "Sync One-Line Detail Items")
-        t.Start()
-        updated = service.sync_associations(selected_associations)
-        t.Commit()
+        warnings = service.get_link_warnings(created)
+        if warnings:
+            forms.alert("Created {} detail item(s) with warnings:\n\n- {}".format(
+                len(created), "\n- ".join(warnings)))
+        else:
+            forms.alert("Created {} detail item(s) and synced {} element(s).".format(len(created), updated))
 
-        forms.alert("Synced {} element(s).".format(updated))
+    window = SyncOneLineWindow(XAML_PATH, list_items, detail_symbols, tag_symbols,
+                               on_sync=on_sync, on_create=on_create)
+    window.ShowDialog()
 
 
 if __name__ == "__main__":

--- a/AE pyTools.extension/AE pyTools.Tab/Electrical.panel/Circuits2.stack/Sync One Line.pushbutton/script.py
+++ b/AE pyTools.extension/AE pyTools.Tab/Electrical.panel/Circuits2.stack/Sync One Line.pushbutton/script.py
@@ -11,6 +11,9 @@ from UIClasses.SyncOneLineWindow import SyncOneLineWindow, SyncOneLineListItem, 
 logger = script.get_logger()
 
 XAML_PATH = os.path.join(os.path.dirname(sync_ui.__file__), "SyncOneLineWindow.xaml")
+_ONE_LINE_WINDOW = None
+_ONE_LINE_HANDLER = None
+_ONE_LINE_EVENT = None
 
 
 def get_element_label(assoc):
@@ -423,8 +426,14 @@ def main():
     detail_symbols = service.collect_detail_symbols()
     tag_symbols = service.collect_tag_symbols()
 
+    global _ONE_LINE_WINDOW
+    global _ONE_LINE_HANDLER
+    global _ONE_LINE_EVENT
+
     handler = OneLineExternalEventHandler(None, service, doc, view, list_items)
     external_event = ExternalEvent.Create(handler)
+    _ONE_LINE_HANDLER = handler
+    _ONE_LINE_EVENT = external_event
 
     def raise_action(action, payload=None):
         handler.set_action(action, payload)
@@ -437,6 +446,7 @@ def main():
                                on_select_detail=lambda: raise_action("select_detail"),
                                on_selection_changed=lambda item: raise_action("update_details", item))
     handler._window = window
+    _ONE_LINE_WINDOW = window
     window.Show()
 
 

--- a/CEDLib.lib/CEDElectrical/Domain/one_line_sync.py
+++ b/CEDLib.lib/CEDElectrical/Domain/one_line_sync.py
@@ -457,25 +457,23 @@ class OneLineSyncService(object):
     # ------------------------------------------------------------------
     # Detail item creation
     # ------------------------------------------------------------------
-    def create_detail_items(self, associations, detail_symbol, view, base_point, tag_symbol=None):
+    def create_detail_items(self, associations, detail_symbol, view, points, tag_symbol=None):
         created = []
-        if not detail_symbol or not view or not base_point:
+        if not detail_symbol or not view or not points:
             return created
 
         if not detail_symbol.IsActive:
             detail_symbol.Activate()
 
-        spacing = 5.0
-
         for index, assoc in enumerate(associations):
-            location = DB.XYZ(base_point.X + (spacing * index), base_point.Y, base_point.Z)
+            location = points[index]
             detail_item = self.doc.Create.NewFamilyInstance(location, detail_symbol, view)
             assoc.detail_elem = detail_item
             created.append(assoc)
 
             if tag_symbol:
                 try:
-                    tag_point = DB.XYZ(base_point.X + (spacing * index), base_point.Y, base_point.Z)
+                    tag_point = location
                     tag = DB.IndependentTag.Create(self.doc, view.Id,
                                                    DB.Reference(detail_item),
                                                    False,

--- a/CEDLib.lib/CEDElectrical/Domain/one_line_sync.py
+++ b/CEDLib.lib/CEDElectrical/Domain/one_line_sync.py
@@ -461,11 +461,19 @@ class OneLineSyncService(object):
             .OfCategory(DB.BuiltInCategory.OST_DetailComponents) \
             .WhereElementIsElementType() \
             .ToElements()
-        return list(symbols)
+        return [sym for sym in symbols
+                if isinstance(sym, DB.FamilySymbol)
+                and sym.Family
+                and sym.Family.Name
+                and sym.Family.Name.startswith("SLD-")]
 
     def collect_tag_symbols(self):
         symbols = DB.FilteredElementCollector(self.doc) \
             .OfCategory(DB.BuiltInCategory.OST_DetailComponentTags) \
             .WhereElementIsElementType() \
             .ToElements()
-        return list(symbols)
+        return [sym for sym in symbols
+                if isinstance(sym, DB.FamilySymbol)
+                and sym.Family
+                and sym.Family.Name
+                and sym.Family.Name.startswith("DI-Tag_SLD")]

--- a/CEDLib.lib/CEDElectrical/Domain/one_line_sync.py
+++ b/CEDLib.lib/CEDElectrical/Domain/one_line_sync.py
@@ -1,0 +1,471 @@
+# -*- coding: utf-8 -*-
+"""Sync one-line detail items with model elements."""
+
+from pyrevit import DB, script
+
+logger = script.get_logger()
+
+DETAIL_PARAM_CKT_PANEL = "CKT_Panel_CEDT"
+DETAIL_PARAM_CKT_NUMBER = "CKT_Circuit Number_CEDT"
+DETAIL_PARAM_PANEL_NAME = "Panel Name_CEDT"
+DETAIL_PARAM_SC_PANEL_ID = "SC_Panel ElementId"
+DETAIL_PARAM_SC_CIRCUIT_ID = "SC_Circuit ElementId"
+DETAIL_PARAM_SC_MODEL_ID = "SC_Model ElementId"
+MODEL_PARAM_SC_DETAIL_ID = "SC_Detail ElementId"
+
+DEVICE_CATEGORY_IDS = [
+    DB.ElementId(DB.BuiltInCategory.OST_ElectricalFixtures),
+    DB.ElementId(DB.BuiltInCategory.OST_LightingFixtures),
+    DB.ElementId(DB.BuiltInCategory.OST_DataDevices)
+]
+
+CIRCUIT_VALUE_MAP = {
+    "x VD Schedule": "x VD Schedule",
+    "Circuit Tree Sort_CED": "Circuit Tree Sort_CED",
+    "CKT_Circuit Type_CEDT": "CKT_Circuit Type_CEDT",
+    "CKT_Panel_CEDT": DB.BuiltInParameter.RBS_ELEC_CIRCUIT_PANEL_PARAM,
+    "CKT_Circuit Number_CEDT": DB.BuiltInParameter.RBS_ELEC_CIRCUIT_NUMBER,
+    "CKT_Load Name_CEDT": DB.BuiltInParameter.RBS_ELEC_CIRCUIT_NAME,
+    "CKT_Rating_CED": DB.BuiltInParameter.RBS_ELEC_CIRCUIT_RATING_PARAM,
+    "CKT_Frame_CED": DB.BuiltInParameter.RBS_ELEC_CIRCUIT_FRAME_PARAM,
+    "CKT_Schedule Notes_CEDT": DB.BuiltInParameter.RBS_ELEC_CIRCUIT_NOTES_PARAM,
+    "CKT_Length_CED": DB.BuiltInParameter.RBS_ELEC_CIRCUIT_LENGTH_PARAM,
+    "Number of Poles_CED": DB.BuiltInParameter.RBS_ELEC_NUMBER_OF_POLES,
+    "Voltage_CED": DB.BuiltInParameter.RBS_ELEC_VOLTAGE,
+    "Wire Material_CEDT": "Wire Material_CEDT",
+    "Wire Insulation_CEDT": "Wire Insulation_CEDT",
+    "Wire Temparature Rating_CEDT": "Wire Temparature Rating_CEDT",
+    "Wire Size_CEDT": "Wire Size_CEDT",
+    "Conduit and Wire Size_CEDT": "Conduit and Wire Size_CEDT",
+    "Conduit Type_CEDT": "Conduit Type_CEDT",
+    "Conduit Size_CEDT": "Conduit Size_CEDT",
+    "Conduit Fill Percentage_CED": "Conduit Fill Percentage_CED",
+    "Voltage Drop Percentage_CED": "Voltage Drop Percentage_CED",
+    "Circuit Load Current_CED": "Circuit Load Current_CED"
+}
+
+PANEL_VALUE_MAP = {
+    "Panel Name_CEDT": DB.BuiltInParameter.RBS_ELEC_PANEL_NAME,
+    "Mains Rating_CED": "Mains Rating_CED",
+    "Mains Type_CEDT": "Mains Type_CEDT",
+    "Phase_CED": "Phase_CED",
+    "Main Breaker Rating_CED": DB.BuiltInParameter.RBS_ELEC_PANEL_MCB_RATING_PARAM,
+    "Short Circuit Rating_CEDT": DB.BuiltInParameter.RBS_ELEC_SHORT_CIRCUIT_RATING,
+    "Mounting_CEDT": DB.BuiltInParameter.RBS_ELEC_MOUNTING,
+    "Panel Modifications_CEDT": DB.BuiltInParameter.RBS_ELEC_MODIFICATIONS,
+    "Distribution System_CEDR": DB.BuiltInParameter.RBS_FAMILY_CONTENT_DISTRIBUTION_SYSTEM,
+    "Secondary Distribution System_CEDR": DB.BuiltInParameter.RBS_FAMILY_CONTENT_SECONDARY_DISTRIBSYS,
+    "Total Connected Load_CEDR": DB.BuiltInParameter.RBS_ELEC_PANEL_TOTALLOAD_PARAM,
+    "Total Demand Load_CEDR": DB.BuiltInParameter.RBS_ELEC_PANEL_TOTAL_DEMAND_CURRENT_PARAM,
+    "Total Connected Current_CEDR": DB.BuiltInParameter.RBS_ELEC_PANEL_TOTAL_CONNECTED_CURRENT_PARAM,
+    "Total Demand Current_CEDR": DB.BuiltInParameter.RBS_ELEC_PANEL_TOTAL_DEMAND_CURRENT_PARAM,
+    "Max Number of Single Pole Breakers_CED": DB.BuiltInParameter.RBS_ELEC_MAX_POLE_BREAKERS,
+    "Max Number of Circuits_CED": DB.BuiltInParameter.RBS_ELEC_NUMBER_OF_CIRCUITS,
+    "Transformer Rating_CEDT": "Transformer Rating_CEDT",
+    "Transformer Rating_CED": "Transformer Rating_CEDT",
+    "Transformer Primary Description_CEDT": "Transformer Primary Description_CEDT",
+    "Transformer Secondary Description_CEDT": "Transformer Secondary Description_CEDT",
+    "Transformer %Z_CED": "Transformer %Z_CED",
+    "Panel Feed_CEDT": DB.BuiltInParameter.RBS_ELEC_PANEL_FEED_PARAM,
+}
+
+DEVICE_VALUE_MAP = {
+    "CKT_Panel_CEDT": "Panel",
+    "CKT_Circuit Number_CEDT": "Circuit Number",
+    "CKT_Load Name_CEDT": "Load Name",
+    "Voltage_CED": "Voltage",
+    "Circuit Load Current_CED": "Load"
+}
+
+
+class SyncAssociation(object):
+    def __init__(self, model_elem, detail_elem, kind, key=None):
+        self.model_elem = model_elem
+        self.detail_elem = detail_elem
+        self.kind = kind
+        self.key = key
+        self.status = None
+
+
+class OneLineSyncService(object):
+    def __init__(self, doc):
+        self.doc = doc
+        self.option_filter = DB.ElementDesignOptionFilter(DB.ElementId.InvalidElementId)
+
+    # ------------------------------------------------------------------
+    # Parameter helpers
+    # ------------------------------------------------------------------
+    def get_model_param_value(self, elem, param_key, allow_type_fallback=True):
+        param = None
+
+        if isinstance(param_key, DB.BuiltInParameter):
+            param = elem.get_Parameter(param_key)
+        elif isinstance(param_key, str):
+            param = elem.LookupParameter(param_key)
+        else:
+            return None
+
+        if not param and allow_type_fallback:
+            try:
+                type_elem = elem.Document.GetElement(elem.GetTypeId())
+                if type_elem:
+                    if isinstance(param_key, DB.BuiltInParameter):
+                        param = type_elem.get_Parameter(param_key)
+                    elif isinstance(param_key, str):
+                        param = type_elem.LookupParameter(param_key)
+            except Exception as exc:
+                logger.debug("get_model_param_value: Error accessing type element {}: {}".format(elem.Id, exc))
+
+        if not param:
+            return None
+
+        st = param.StorageType
+        if st == DB.StorageType.String:
+            return param.AsString()
+        elif st == DB.StorageType.Integer:
+            return param.AsInteger()
+        elif st == DB.StorageType.Double:
+            return param.AsDouble()
+        elif st == DB.StorageType.ElementId:
+            return param.AsValueString()
+
+        return None
+
+    def get_detail_param_value(self, elem, param_name):
+        param = elem.LookupParameter(param_name)
+        if not param:
+            return None
+
+        st = param.StorageType
+        if st == DB.StorageType.String:
+            return param.AsString()
+        elif st == DB.StorageType.Integer:
+            return param.AsInteger()
+        elif st == DB.StorageType.Double:
+            return param.AsDouble()
+        elif st == DB.StorageType.ElementId:
+            return param.AsValueString()
+        return None
+
+    def set_param_value(self, elem, param_name, new_value):
+        param = elem.LookupParameter(param_name)
+        if not param or param.IsReadOnly:
+            return False
+
+        try:
+            if new_value is None:
+                if param.StorageType == DB.StorageType.String:
+                    param.Set("")
+                elif param.StorageType == DB.StorageType.Integer:
+                    param.Set(0)
+                elif param.StorageType == DB.StorageType.Double:
+                    param.Set(0.0)
+                return True
+
+            if param.StorageType == DB.StorageType.String:
+                param.Set(str(new_value))
+            elif param.StorageType == DB.StorageType.Integer:
+                param.Set(int(new_value))
+            elif param.StorageType == DB.StorageType.Double:
+                param.Set(float(new_value))
+            elif param.StorageType == DB.StorageType.ElementId and isinstance(new_value, DB.ElementId):
+                param.Set(new_value)
+            else:
+                param.Set(str(new_value))
+            return True
+        except Exception:
+            return False
+
+    def _normalize(self, value):
+        if value is None:
+            return ""
+        return str(value).strip()
+
+    # ------------------------------------------------------------------
+    # Collect elements
+    # ------------------------------------------------------------------
+    def collect_circuits(self):
+        return DB.FilteredElementCollector(self.doc) \
+            .OfClass(DB.Electrical.ElectricalSystem) \
+            .WherePasses(self.option_filter) \
+            .ToElements()
+
+    def collect_panels(self):
+        return DB.FilteredElementCollector(self.doc) \
+            .OfCategory(DB.BuiltInCategory.OST_ElectricalEquipment) \
+            .WhereElementIsNotElementType() \
+            .WherePasses(self.option_filter) \
+            .ToElements()
+
+    def collect_devices(self):
+        elems = []
+        for cat_id in DEVICE_CATEGORY_IDS:
+            elems.extend(DB.FilteredElementCollector(self.doc)
+                         .OfCategoryId(cat_id)
+                         .WhereElementIsNotElementType()
+                         .WherePasses(self.option_filter)
+                         .ToElements())
+        return elems
+
+    def collect_detail_items(self):
+        return DB.FilteredElementCollector(self.doc) \
+            .OfCategory(DB.BuiltInCategory.OST_DetailComponents) \
+            .WhereElementIsNotElementType() \
+            .WherePasses(self.option_filter) \
+            .ToElements()
+
+    # ------------------------------------------------------------------
+    # Detail item associations
+    # ------------------------------------------------------------------
+    def get_circuit_key(self, circuit):
+        panel_val = self.get_model_param_value(circuit, DB.BuiltInParameter.RBS_ELEC_CIRCUIT_PANEL_PARAM)
+        cnum_val = self.get_model_param_value(circuit, DB.BuiltInParameter.RBS_ELEC_CIRCUIT_NUMBER)
+        if panel_val and cnum_val:
+            return (str(panel_val), str(cnum_val))
+        return None
+
+    def get_panel_key(self, panel):
+        pname = self.get_model_param_value(panel, DB.BuiltInParameter.RBS_ELEC_PANEL_NAME)
+        if pname:
+            return str(pname)
+        return None
+
+    def get_device_circuit_key(self, device):
+        panel_val = None
+        cnum_val = None
+
+        try:
+            mep = device.MEPModel
+            if mep:
+                assigned = mep.GetAssignedElectricalSystems()
+                if assigned and len(assigned) > 0:
+                    ckt = assigned[0]
+                    panel_val = self.get_model_param_value(ckt, DB.BuiltInParameter.RBS_ELEC_CIRCUIT_PANEL_PARAM)
+                    cnum_val = self.get_model_param_value(ckt, DB.BuiltInParameter.RBS_ELEC_CIRCUIT_NUMBER)
+        except Exception:
+            pass
+
+        if not panel_val:
+            panel_val = self.get_model_param_value(device, "Panel")
+        if not cnum_val:
+            cnum_val = self.get_model_param_value(device, "Circuit Number")
+
+        if panel_val and cnum_val:
+            return (str(panel_val), str(cnum_val))
+        return None
+
+    def build_detail_lookup(self, detail_items):
+        detail_by_model_id = {}
+        detail_by_id = {}
+        detail_by_circuit = {}
+        detail_by_panel = {}
+
+        for ditem in detail_items:
+            detail_by_id[str(ditem.Id.IntegerValue)] = ditem
+
+            model_id = self.get_detail_param_value(ditem, DETAIL_PARAM_SC_MODEL_ID)
+            if model_id:
+                detail_by_model_id[str(model_id).strip()] = ditem
+
+            panel_val = self.get_detail_param_value(ditem, DETAIL_PARAM_CKT_PANEL)
+            cnum_val = self.get_detail_param_value(ditem, DETAIL_PARAM_CKT_NUMBER)
+            if panel_val and cnum_val:
+                detail_by_circuit[(str(panel_val), str(cnum_val))] = ditem
+
+            pname_val = self.get_detail_param_value(ditem, DETAIL_PARAM_PANEL_NAME)
+            if pname_val:
+                detail_by_panel[str(pname_val)] = ditem
+            elif panel_val:
+                detail_by_panel[str(panel_val)] = ditem
+
+        return detail_by_model_id, detail_by_id, detail_by_circuit, detail_by_panel
+
+    def get_associated_detail(self, model_elem, model_id, detail_by_model_id, detail_by_id, fallback_key=None,
+                              detail_by_circuit=None, detail_by_panel=None):
+        detail_elem = None
+
+        detail_id_val = self.get_model_param_value(model_elem, MODEL_PARAM_SC_DETAIL_ID, allow_type_fallback=False)
+        if detail_id_val:
+            detail_elem = detail_by_id.get(str(detail_id_val).strip())
+
+        if not detail_elem:
+            detail_elem = detail_by_model_id.get(str(model_id))
+
+        if not detail_elem and fallback_key:
+            if detail_by_circuit and isinstance(fallback_key, tuple):
+                detail_elem = detail_by_circuit.get(fallback_key)
+            elif detail_by_panel and isinstance(fallback_key, str):
+                detail_elem = detail_by_panel.get(fallback_key)
+
+        return detail_elem
+
+    def build_associations(self):
+        circuits = self.collect_circuits()
+        panels = self.collect_panels()
+        devices = self.collect_devices()
+        detail_items = self.collect_detail_items()
+
+        detail_by_model_id, detail_by_id, detail_by_circuit, detail_by_panel = self.build_detail_lookup(detail_items)
+        associations = []
+
+        for circuit in circuits:
+            key = self.get_circuit_key(circuit)
+            detail_elem = self.get_associated_detail(circuit, circuit.Id.IntegerValue, detail_by_model_id, detail_by_id,
+                                                     fallback_key=key, detail_by_circuit=detail_by_circuit)
+            assoc = SyncAssociation(circuit, detail_elem, "circuit", key=key)
+            associations.append(assoc)
+
+        for panel in panels:
+            key = self.get_panel_key(panel)
+            detail_elem = self.get_associated_detail(panel, panel.Id.IntegerValue, detail_by_model_id, detail_by_id,
+                                                     fallback_key=key, detail_by_panel=detail_by_panel)
+            assoc = SyncAssociation(panel, detail_elem, "panel", key=key)
+            associations.append(assoc)
+
+        for device in devices:
+            key = self.get_device_circuit_key(device)
+            detail_elem = self.get_associated_detail(device, device.Id.IntegerValue, detail_by_model_id, detail_by_id,
+                                                     fallback_key=key, detail_by_circuit=detail_by_circuit)
+            assoc = SyncAssociation(device, detail_elem, "device", key=key)
+            associations.append(assoc)
+
+        for assoc in associations:
+            assoc.status = self.compute_status(assoc)
+
+        return associations
+
+    # ------------------------------------------------------------------
+    # Status + syncing
+    # ------------------------------------------------------------------
+    def compute_status(self, assoc):
+        if not assoc.detail_elem:
+            return "missing"
+
+        if self.is_outdated(assoc):
+            return "outdated"
+        return "linked"
+
+    def is_outdated(self, assoc):
+        if assoc.kind == "circuit":
+            value_map = CIRCUIT_VALUE_MAP
+        elif assoc.kind == "panel":
+            value_map = PANEL_VALUE_MAP
+        else:
+            value_map = DEVICE_VALUE_MAP
+
+        for detail_param, model_param in value_map.items():
+            model_val = self.get_model_param_value(assoc.model_elem, model_param)
+            detail_val = self.get_detail_param_value(assoc.detail_elem, detail_param)
+            if self._normalize(model_val) != self._normalize(detail_val):
+                return True
+
+        return False
+
+    def sync_associations(self, associations):
+        updated = 0
+
+        for assoc in associations:
+            if not assoc.detail_elem:
+                continue
+
+            if assoc.kind == "circuit":
+                updated += self._sync_circuit(assoc)
+            elif assoc.kind == "panel":
+                updated += self._sync_panel(assoc)
+            else:
+                updated += self._sync_device(assoc)
+
+        return updated
+
+    def _sync_common_ids(self, assoc):
+        self.set_param_value(assoc.detail_elem, DETAIL_PARAM_SC_MODEL_ID, str(assoc.model_elem.Id.IntegerValue))
+        self.set_param_value(assoc.model_elem, MODEL_PARAM_SC_DETAIL_ID, str(assoc.detail_elem.Id.IntegerValue))
+
+    def _sync_circuit(self, assoc):
+        for detail_param, model_param in CIRCUIT_VALUE_MAP.items():
+            value = self.get_model_param_value(assoc.model_elem, model_param)
+            self.set_param_value(assoc.detail_elem, detail_param, value)
+
+        self.set_param_value(assoc.detail_elem, DETAIL_PARAM_SC_CIRCUIT_ID, str(assoc.model_elem.Id.IntegerValue))
+        try:
+            panel_elem = assoc.model_elem.BaseEquipment
+            if panel_elem:
+                self.set_param_value(assoc.detail_elem, DETAIL_PARAM_SC_PANEL_ID, str(panel_elem.Id.IntegerValue))
+        except Exception:
+            pass
+
+        self._sync_common_ids(assoc)
+        return 1
+
+    def _sync_panel(self, assoc):
+        for detail_param, model_param in PANEL_VALUE_MAP.items():
+            value = self.get_model_param_value(assoc.model_elem, model_param)
+            self.set_param_value(assoc.detail_elem, detail_param, value)
+
+        self.set_param_value(assoc.detail_elem, DETAIL_PARAM_SC_PANEL_ID, str(assoc.model_elem.Id.IntegerValue))
+        self._sync_common_ids(assoc)
+        return 1
+
+    def _sync_device(self, assoc):
+        for detail_param, model_param in DEVICE_VALUE_MAP.items():
+            value = self.get_model_param_value(assoc.model_elem, model_param)
+            self.set_param_value(assoc.detail_elem, detail_param, value)
+
+        self._sync_common_ids(assoc)
+        return 1
+
+    # ------------------------------------------------------------------
+    # Detail item creation
+    # ------------------------------------------------------------------
+    def create_detail_items(self, associations, detail_symbol, view, tag_symbol=None):
+        created = []
+        if not detail_symbol or not view:
+            return created
+
+        if not detail_symbol.IsActive:
+            detail_symbol.Activate()
+
+        base_x = 0.0
+        base_y = 0.0
+        spacing = 5.0
+
+        for index, assoc in enumerate(associations):
+            if assoc.kind != "panel":
+                continue
+
+            location = DB.XYZ(base_x + (spacing * index), base_y, 0)
+            detail_item = self.doc.Create.NewFamilyInstance(location, detail_symbol, view)
+            assoc.detail_elem = detail_item
+            created.append(assoc)
+
+            if tag_symbol:
+                try:
+                    tag_point = DB.XYZ(base_x + (spacing * index), base_y - spacing, 0)
+                    tag = DB.IndependentTag.Create(self.doc, view.Id,
+                                                   DB.Reference(detail_item),
+                                                   False,
+                                                   DB.TagMode.TM_ADDBY_CATEGORY,
+                                                   DB.TagOrientation.Horizontal,
+                                                   tag_point)
+                    tag.ChangeTypeId(tag_symbol.Id)
+                except Exception:
+                    pass
+
+        return created
+
+    # ------------------------------------------------------------------
+    # Detail item family helpers
+    # ------------------------------------------------------------------
+    def collect_detail_symbols(self):
+        symbols = DB.FilteredElementCollector(self.doc) \
+            .OfCategory(DB.BuiltInCategory.OST_DetailComponents) \
+            .WhereElementIsElementType() \
+            .ToElements()
+        return list(symbols)
+
+    def collect_tag_symbols(self):
+        symbols = DB.FilteredElementCollector(self.doc) \
+            .OfCategory(DB.BuiltInCategory.OST_DetailComponentTags) \
+            .WhereElementIsElementType() \
+            .ToElements()
+        return list(symbols)

--- a/CEDLib.lib/CEDElectrical/Domain/one_line_tree.py
+++ b/CEDLib.lib/CEDElectrical/Domain/one_line_tree.py
@@ -1,0 +1,173 @@
+# -*- coding: utf-8 -*-
+"""One-line system tree helpers.
+
+Extracted from the OneLine22 testing script so it can be reused for
+list boxes and branch calculations.
+"""
+
+from pyrevit import DB
+from pyrevit.compat import get_elementid_value_func
+
+get_id_value = get_elementid_value_func()
+
+
+class TreeBranch(object):
+    def __init__(self, system):
+        self.element_id = system.Id
+        self.base_eq = system.BaseEquipment
+        self.base_eq_id = self.base_eq.Id if self.base_eq else DB.ElementId.InvalidElementId
+        self.base_eq_name = DB.Element.Name.__get__(self.base_eq) if self.base_eq else "Unknown"
+        self.circuit_number = system.CircuitNumber
+        self.load_name = system.LoadName
+        self.system = system
+        self.is_feeder = False  # Set True if it connects two equipment nodes
+
+    def __str__(self):
+        return "- Circuit `{}` | Load `{}` | Feeder `{}`".format(
+            self.circuit_number, self.load_name, self.is_feeder
+        )
+
+    def to_dict(self, parent_node=None):
+        return {
+            "Parent Panel": parent_node.panel_name if parent_node else "",
+            "Parent ID": parent_node.element_id if parent_node else "",
+            "Circuit Number": self.circuit_number,
+            "Load Name": self.load_name,
+            "Branch ID": self.element_id,
+            "From Panel": self.base_eq_name,
+            "Feeder": self.is_feeder
+        }
+
+
+class TreeNode(object):
+    PART_TYPE_MAP = {
+        14: "Panelboard",
+        15: "Transformer",
+        16: "Switchboard",
+        17: "Other Panel",
+        18: "Equipment Switch"
+    }
+
+    def __init__(self, element):
+        self.element = element
+        self.element_id = element.Id
+        self.panel_name = DB.Element.Name.__get__(element)
+        self.upstream = []
+        self.downstream = []
+        self.is_leaf = False
+        self._part_type = self.get_family_part_type()
+        self.equipment_type = self.PART_TYPE_MAP.get(self._part_type, "Unknown")
+
+    def to_dict(self):
+        return {
+            "Panel Name": self.panel_name,
+            "Element ID": self.element_id,
+            "Equipment Type": self.equipment_type,
+            "Is Leaf": self.is_leaf,
+            "Upstream Count": len(self.upstream),
+            "Downstream Count": len(self.downstream)
+        }
+
+    def get_family_part_type(self):
+        if not self.element or not isinstance(self.element, DB.FamilyInstance):
+            return None
+
+        symbol = self.element.Symbol
+        if not symbol:
+            return None
+
+        family = symbol.Family
+        if not family:
+            return None
+
+        param = family.get_Parameter(DB.BuiltInParameter.FAMILY_CONTENT_PART_TYPE)
+        if param and param.HasValue:
+            return param.AsInteger()
+        return None
+
+    def collect_branches(self):
+        mep = self.element.MEPModel
+        if not mep:
+            return
+
+        all_systems = mep.GetElectricalSystems()
+        assigned = mep.GetAssignedElectricalSystems()
+        assigned_ids = set([sys.Id for sys in assigned]) if assigned else set()
+
+        for sys in all_systems:
+            br = TreeBranch(sys)
+            if br.base_eq_id == self.element_id:
+                self.downstream.append(br)
+            else:
+                self.upstream.append(br)
+
+        # Leaf check
+        self.is_leaf = not assigned or len(assigned) == 0
+
+
+class SystemTree(object):
+    def __init__(self):
+        self.nodes = {}      # {element_id: TreeNode}
+        self.root_nodes = [] # list of TreeNode
+
+    def add_node(self, node):
+        self.nodes[node.element_id] = node
+        if not node.upstream:
+            self.root_nodes.append(node)
+
+    def get_node(self, element_id):
+        return self.nodes.get(element_id)
+
+    def to_list(self):
+        data = []
+
+        for node in self.nodes.values():
+            node_record = node.to_dict()
+            for branch in node.downstream:
+                branch_record = branch.to_dict(parent_node=node)
+                combined = dict(node_record)
+                combined.update(branch_record)
+                data.append(combined)
+
+        return data
+
+    def walk_tree(self, node, visitor, visited=None, level=0):
+        if visited is None:
+            visited = set()
+
+        visitor(node, level)
+        visited.add(node.element_id)
+
+        for branch in node.downstream:
+            visitor(branch, level + 1)
+
+            system = branch.system
+            if hasattr(system, "Elements"):
+                for elem in list(system.Elements):
+                    if elem.Category and int(get_id_value(elem.Category.Id)) == int(DB.BuiltInCategory.OST_ElectricalEquipment):
+                        if elem.Id not in visited:
+                            branch.is_feeder = True
+                            child_node = self.nodes.get(elem.Id)
+                            if child_node:
+                                self.walk_tree(child_node, visitor, visited, level + 2)
+
+
+def get_all_equipment_nodes(doc):
+    nodes = {}
+    collector = DB.FilteredElementCollector(doc) \
+        .OfCategory(DB.BuiltInCategory.OST_ElectricalEquipment) \
+        .WhereElementIsNotElementType()
+
+    for equip in collector:
+        node = TreeNode(equip)
+        node.collect_branches()
+        nodes[equip.Id] = node
+    return nodes
+
+
+def build_system_tree(doc):
+    equipment_map = get_all_equipment_nodes(doc)
+    tree = SystemTree()
+    for node in equipment_map.values():
+        tree.add_node(node)
+    return tree

--- a/CEDLib.lib/UIClasses/SyncOneLineWindow.py
+++ b/CEDLib.lib/UIClasses/SyncOneLineWindow.py
@@ -17,7 +17,8 @@ class SyncOneLineListItem(object):
 
 
 class SyncOneLineWindow(forms.WPFWindow):
-    def __init__(self, xaml_path, items, detail_symbols, tag_symbols, on_sync=None, on_create=None):
+    def __init__(self, xaml_path, items, detail_symbols, tag_symbols, on_sync=None, on_create=None,
+                 on_select_model=None, on_select_detail=None, on_selection_changed=None):
         forms.WPFWindow.__init__(self, xaml_path)
 
         self._all_items = items
@@ -25,6 +26,9 @@ class SyncOneLineWindow(forms.WPFWindow):
         self._tag_symbols = tag_symbols or []
         self._on_sync = on_sync
         self._on_create = on_create
+        self._on_select_model = on_select_model
+        self._on_select_detail = on_select_detail
+        self._on_selection_changed = on_selection_changed
         self._sort_mode = "Flat"
 
         self._build_detail_combo()
@@ -70,7 +74,8 @@ class SyncOneLineWindow(forms.WPFWindow):
                 item.display_text = item.tree_text
             else:
                 item.display_text = item.base_text
-        self.ElementsList.ItemsSource = items
+        self.ElementsList.ItemsSource = None
+        self.ElementsList.ItemsSource = list(items)
 
     def _status_allowed(self, status):
         if status == "linked":
@@ -173,6 +178,27 @@ class SyncOneLineWindow(forms.WPFWindow):
 
     def refresh_items(self):
         self._refresh_list(self._filter_items(self.SearchBox.Text))
+
+    def ElementsList_SelectionChanged(self, sender, args):
+        selected_item = None
+        if self.ElementsList.SelectedItems and self.ElementsList.SelectedItems.Count > 0:
+            selected_item = self.ElementsList.SelectedItems[0]
+        if self._on_selection_changed:
+            self._on_selection_changed(selected_item)
+
+    def SelectModelButton_Click(self, sender, args):
+        if self._on_select_model:
+            self._on_select_model()
+
+    def SelectDetailButton_Click(self, sender, args):
+        if self._on_select_detail:
+            self._on_select_detail()
+
+    def set_detail_panel(self, label_text, model_id_text, detail_id_text, status_lines):
+        self.SelectedLabelText.Text = label_text or "(none)"
+        self.ModelIdText.Text = model_id_text or "-"
+        self.DetailIdText.Text = detail_id_text or "-"
+        self.DetailStatusList.ItemsSource = status_lines or []
 
 
 def status_symbol(status):

--- a/CEDLib.lib/UIClasses/SyncOneLineWindow.py
+++ b/CEDLib.lib/UIClasses/SyncOneLineWindow.py
@@ -17,11 +17,13 @@ class SyncOneLineListItem(object):
 
 
 class SyncOneLineWindow(forms.WPFWindow):
-    def __init__(self, xaml_path, items, detail_symbols, tag_symbols, on_sync=None, on_create=None,
+    def __init__(self, xaml_path, flat_items, tree_items, detail_symbols, tag_symbols, on_sync=None, on_create=None,
                  on_select_model=None, on_select_detail=None, on_selection_changed=None):
         forms.WPFWindow.__init__(self, xaml_path)
 
-        self._all_items = items
+        self._flat_items = flat_items
+        self._tree_items = tree_items
+        self._all_items = list(flat_items)
         self._detail_symbols = detail_symbols or []
         self._tag_symbols = tag_symbols or []
         self._on_sync = on_sync
@@ -88,8 +90,9 @@ class SyncOneLineWindow(forms.WPFWindow):
 
     def _filter_items(self, search_text):
         search_text = (search_text or "").lower()
+        base_items = self._tree_items if self._sort_mode == "Tree" else self._flat_items
         filtered = []
-        for item in self._all_items:
+        for item in base_items:
             if not self._status_allowed(item.association.status):
                 continue
             text = item.display_text.lower()

--- a/CEDLib.lib/UIClasses/SyncOneLineWindow.py
+++ b/CEDLib.lib/UIClasses/SyncOneLineWindow.py
@@ -1,0 +1,124 @@
+# -*- coding: utf-8 -*-
+"""WPF window for Sync One-Line."""
+
+from pyrevit import forms
+from System.Windows.Media import Brushes
+
+
+class SyncOneLineListItem(object):
+    def __init__(self, association, display_text, status_symbol, status_brush):
+        self.association = association
+        self.display_text = display_text
+        self.status_symbol = status_symbol
+        self.status_brush = status_brush
+        self.is_checked = False
+
+
+class SyncOneLineWindow(forms.WPFWindow):
+    def __init__(self, xaml_path, items, detail_symbols, tag_symbols):
+        forms.WPFWindow.__init__(self, xaml_path)
+
+        self._all_items = items
+        self._detail_symbols = detail_symbols or []
+        self._tag_symbols = tag_symbols or []
+        self.requested_action = None
+
+        self._build_detail_combo()
+        self._build_tag_combo()
+        self._refresh_list(self._all_items)
+
+    def _build_detail_combo(self):
+        families = []
+        seen = set()
+        for symbol in self._detail_symbols:
+            family_name = symbol.Family.Name
+            if family_name not in seen:
+                families.append(symbol.Family)
+                seen.add(family_name)
+
+        self.DetailFamilyCombo.ItemsSource = families
+        if families:
+            self.DetailFamilyCombo.SelectedIndex = 0
+
+    def _build_tag_combo(self):
+        families = []
+        seen = set()
+        for symbol in self._tag_symbols:
+            family_name = symbol.Family.Name
+            if family_name not in seen:
+                families.append(symbol.Family)
+                seen.add(family_name)
+
+        families.insert(0, None)
+        self.TagFamilyCombo.ItemsSource = families
+        self.TagFamilyCombo.SelectedIndex = 0
+
+    def _refresh_list(self, items):
+        self.ElementsList.ItemsSource = items
+
+    def _filter_items(self, search_text):
+        if not search_text:
+            return self._all_items
+
+        search_text = search_text.lower()
+        return [item for item in self._all_items if search_text in item.display_text.lower()]
+
+    def _update_detail_types(self):
+        family = self.DetailFamilyCombo.SelectedItem
+        if not family:
+            self.DetailTypeCombo.ItemsSource = []
+            return
+
+        types = [sym for sym in self._detail_symbols if sym.Family.Id == family.Id]
+        self.DetailTypeCombo.ItemsSource = types
+        if types:
+            self.DetailTypeCombo.SelectedIndex = 0
+
+    def _update_tag_types(self):
+        family = self.TagFamilyCombo.SelectedItem
+        if not family:
+            self.TagTypeCombo.ItemsSource = []
+            return
+
+        types = [sym for sym in self._tag_symbols if sym.Family.Id == family.Id]
+        self.TagTypeCombo.ItemsSource = types
+        if types:
+            self.TagTypeCombo.SelectedIndex = 0
+
+    def get_selected_associations(self):
+        return [item.association for item in self._all_items if item.is_checked]
+
+    def get_selected_detail_symbol(self):
+        return self.DetailTypeCombo.SelectedItem
+
+    def get_selected_tag_symbol(self):
+        return self.TagTypeCombo.SelectedItem
+
+    def SearchBox_TextChanged(self, sender, args):
+        self._refresh_list(self._filter_items(self.SearchBox.Text))
+
+    def DetailFamilyCombo_SelectionChanged(self, sender, args):
+        self._update_detail_types()
+
+    def TagFamilyCombo_SelectionChanged(self, sender, args):
+        self._update_tag_types()
+
+    def CreateButton_Click(self, sender, args):
+        self.requested_action = "create"
+        self.Close()
+
+    def SyncButton_Click(self, sender, args):
+        self.requested_action = "sync"
+        self.Close()
+
+    def CancelButton_Click(self, sender, args):
+        self.requested_action = None
+        self.Close()
+
+
+def status_symbol(status):
+    if status == "linked":
+        return "●", Brushes.Green
+    if status == "outdated":
+        return "●", Brushes.Orange
+    return "●", Brushes.Red

--- a/CEDLib.lib/UIClasses/SyncOneLineWindow.py
+++ b/CEDLib.lib/UIClasses/SyncOneLineWindow.py
@@ -31,9 +31,12 @@ class SyncOneLineWindow(forms.WPFWindow):
         families = []
         seen = set()
         for symbol in self._detail_symbols:
-            family_name = symbol.Family.Name
+            family = getattr(symbol, "Family", None)
+            if not family:
+                continue
+            family_name = family.Name
             if family_name not in seen:
-                families.append(symbol.Family)
+                families.append(family)
                 seen.add(family_name)
 
         self.DetailFamilyCombo.ItemsSource = families
@@ -44,9 +47,12 @@ class SyncOneLineWindow(forms.WPFWindow):
         families = []
         seen = set()
         for symbol in self._tag_symbols:
-            family_name = symbol.Family.Name
+            family = getattr(symbol, "Family", None)
+            if not family:
+                continue
+            family_name = family.Name
             if family_name not in seen:
-                families.append(symbol.Family)
+                families.append(family)
                 seen.add(family_name)
 
         families.insert(0, None)

--- a/CEDLib.lib/UIClasses/SyncOneLineWindow.xaml
+++ b/CEDLib.lib/UIClasses/SyncOneLineWindow.xaml
@@ -1,0 +1,78 @@
+<Window
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Sync One-Line Data"
+        Height="720" Width="980"
+        WindowStartupLocation="CenterScreen"
+        ResizeMode="CanResizeWithGrip">
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,10">
+            <TextBlock Text="Search:" VerticalAlignment="Center" Margin="0,0,6,0"/>
+            <TextBox x:Name="SearchBox" Width="280" TextChanged="SearchBox_TextChanged"/>
+            <TextBlock Text="Legend:" VerticalAlignment="Center" Margin="20,0,6,0"/>
+            <TextBlock Text="●" Foreground="Green" VerticalAlignment="Center" Margin="0,0,4,0"/>
+            <TextBlock Text="Linked" VerticalAlignment="Center" Margin="0,0,12,0"/>
+            <TextBlock Text="●" Foreground="Orange" VerticalAlignment="Center" Margin="0,0,4,0"/>
+            <TextBlock Text="Outdated" VerticalAlignment="Center" Margin="0,0,12,0"/>
+            <TextBlock Text="●" Foreground="Red" VerticalAlignment="Center" Margin="0,0,4,0"/>
+            <TextBlock Text="Missing" VerticalAlignment="Center"/>
+        </StackPanel>
+
+        <GroupBox Grid.Row="1" Header="Model Elements">
+            <ListBox x:Name="ElementsList" Margin="5">
+                <ListBox.ItemTemplate>
+                    <DataTemplate>
+                        <CheckBox IsChecked="{Binding is_checked}">
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="{Binding status_symbol}" Foreground="{Binding status_brush}" Margin="0,0,6,0"/>
+                                <TextBlock Text="{Binding display_text}"/>
+                            </StackPanel>
+                        </CheckBox>
+                    </DataTemplate>
+                </ListBox.ItemTemplate>
+            </ListBox>
+        </GroupBox>
+
+        <Grid Grid.Row="2" Margin="0,10,0,10">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+
+            <StackPanel Grid.Column="0" Margin="0,0,8,0">
+                <TextBlock Text="Detail Item Family" Margin="0,0,0,4"/>
+                <ComboBox x:Name="DetailFamilyCombo" SelectionChanged="DetailFamilyCombo_SelectionChanged"/>
+            </StackPanel>
+
+            <StackPanel Grid.Column="1" Margin="0,0,8,0">
+                <TextBlock Text="Detail Item Type" Margin="0,0,0,4"/>
+                <ComboBox x:Name="DetailTypeCombo"/>
+            </StackPanel>
+
+            <StackPanel Grid.Column="2" Margin="0,0,8,0">
+                <TextBlock Text="Tag Family (Optional)" Margin="0,0,0,4"/>
+                <ComboBox x:Name="TagFamilyCombo" SelectionChanged="TagFamilyCombo_SelectionChanged"/>
+            </StackPanel>
+
+            <StackPanel Grid.Column="3">
+                <TextBlock Text="Tag Type" Margin="0,0,0,4"/>
+                <ComboBox x:Name="TagTypeCombo"/>
+            </StackPanel>
+        </Grid>
+
+        <StackPanel Grid.Row="3" Orientation="Horizontal" HorizontalAlignment="Right">
+            <Button x:Name="CreateButton" Content="Create Detail Items" Width="170" Margin="0,0,10,0" Click="CreateButton_Click"/>
+            <Button x:Name="SyncButton" Content="Sync Selected" Width="130" Margin="0,0,10,0" Click="SyncButton_Click"/>
+            <Button x:Name="CancelButton" Content="Cancel" Width="90" Click="CancelButton_Click"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/CEDLib.lib/UIClasses/SyncOneLineWindow.xaml
+++ b/CEDLib.lib/UIClasses/SyncOneLineWindow.xaml
@@ -29,20 +29,46 @@
             <Button x:Name="SelectNoneButton" Content="Select None" Width="90" Click="SelectNoneButton_Click"/>
         </StackPanel>
 
-        <GroupBox Grid.Row="1" Header="Model Elements">
-            <ListBox x:Name="ElementsList" Margin="5" SelectionMode="Extended">
-                <ListBox.ItemTemplate>
-                    <DataTemplate>
-                        <CheckBox IsChecked="{Binding is_checked}" Click="ItemCheckBox_Click">
-                            <StackPanel Orientation="Horizontal">
-                                <TextBlock Text="{Binding status_symbol}" Foreground="{Binding status_brush}" Margin="0,0,6,0"/>
-                                <TextBlock Text="{Binding display_text}"/>
-                            </StackPanel>
-                        </CheckBox>
-                    </DataTemplate>
-                </ListBox.ItemTemplate>
-            </ListBox>
-        </GroupBox>
+        <Grid Grid.Row="1">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="320"/>
+            </Grid.ColumnDefinitions>
+            <GroupBox Grid.Column="0" Header="Model Elements">
+                <ListBox x:Name="ElementsList" Margin="5" SelectionMode="Extended" SelectionChanged="ElementsList_SelectionChanged">
+                    <ListBox.ItemTemplate>
+                        <DataTemplate>
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="22"/>
+                                    <ColumnDefinition Width="22"/>
+                                    <ColumnDefinition Width="*"/>
+                                </Grid.ColumnDefinitions>
+                                <CheckBox Grid.Column="0" IsChecked="{Binding is_checked}" Click="ItemCheckBox_Click" VerticalAlignment="Center"/>
+                                <TextBlock Grid.Column="1" Text="{Binding status_symbol}" Foreground="{Binding status_brush}" VerticalAlignment="Center"/>
+                                <TextBlock Grid.Column="2" Text="{Binding display_text}" VerticalAlignment="Center"/>
+                            </Grid>
+                        </DataTemplate>
+                    </ListBox.ItemTemplate>
+                </ListBox>
+            </GroupBox>
+            <GroupBox Grid.Column="1" Header="Selection Details" Margin="10,0,0,0">
+                <StackPanel Margin="6">
+                    <TextBlock Text="Selected:" FontWeight="Bold" Margin="0,0,0,4"/>
+                    <TextBlock x:Name="SelectedLabelText" Text="(none)" TextWrapping="Wrap"/>
+                    <TextBlock Text="Model Element Id:" FontWeight="Bold" Margin="0,8,0,2"/>
+                    <TextBlock x:Name="ModelIdText" Text="-" />
+                    <TextBlock Text="Detail Item Id:" FontWeight="Bold" Margin="0,8,0,2"/>
+                    <TextBlock x:Name="DetailIdText" Text="-" />
+                    <StackPanel Orientation="Horizontal" Margin="0,8,0,8">
+                        <Button x:Name="SelectModelButton" Content="Select Model" Width="130" Margin="0,0,8,0" Click="SelectModelButton_Click"/>
+                        <Button x:Name="SelectDetailButton" Content="Select Detail" Width="130" Click="SelectDetailButton_Click"/>
+                    </StackPanel>
+                    <TextBlock Text="Parameter Status:" FontWeight="Bold" Margin="0,4,0,4"/>
+                    <ListBox x:Name="DetailStatusList" Height="240"/>
+                </StackPanel>
+            </GroupBox>
+        </Grid>
 
         <Grid Grid.Row="2" Margin="0,10,0,10">
             <Grid.ColumnDefinitions>

--- a/CEDLib.lib/UIClasses/SyncOneLineWindow.xaml
+++ b/CEDLib.lib/UIClasses/SyncOneLineWindow.xaml
@@ -44,7 +44,7 @@
                                     <ColumnDefinition Width="22"/>
                                     <ColumnDefinition Width="*"/>
                                 </Grid.ColumnDefinitions>
-                                <CheckBox Grid.Column="0" IsChecked="{Binding is_checked}" Click="ItemCheckBox_Click" VerticalAlignment="Center"/>
+                                <CheckBox Grid.Column="0" Width="16" Margin="2,0,2,0" IsChecked="{Binding is_checked}" Click="ItemCheckBox_Click" VerticalAlignment="Center" HorizontalAlignment="Left" Focusable="False"/>
                                 <TextBlock Grid.Column="1" Text="{Binding status_symbol}" Foreground="{Binding status_brush}" VerticalAlignment="Center"/>
                                 <TextBlock Grid.Column="2" Text="{Binding display_text}" VerticalAlignment="Center"/>
                             </Grid>

--- a/CEDLib.lib/UIClasses/SyncOneLineWindow.xaml
+++ b/CEDLib.lib/UIClasses/SyncOneLineWindow.xaml
@@ -16,10 +16,8 @@
         <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,10">
             <TextBlock Text="Search:" VerticalAlignment="Center" Margin="0,0,6,0"/>
             <TextBox x:Name="SearchBox" Width="220" TextChanged="SearchBox_TextChanged"/>
-            <TextBlock Text="Status:" VerticalAlignment="Center" Margin="12,0,6,0"/>
-            <CheckBox x:Name="FilterLinked" Content="Linked" IsChecked="True" Margin="0,0,8,0" Checked="FilterStatus_Changed" Unchecked="FilterStatus_Changed"/>
-            <CheckBox x:Name="FilterOutdated" Content="Outdated" IsChecked="True" Margin="0,0,8,0" Checked="FilterStatus_Changed" Unchecked="FilterStatus_Changed"/>
-            <CheckBox x:Name="FilterMissing" Content="Missing" IsChecked="True" Margin="0,0,12,0" Checked="FilterStatus_Changed" Unchecked="FilterStatus_Changed"/>
+            <TextBlock Text="Filters:" VerticalAlignment="Center" Margin="12,0,6,0"/>
+            <Button x:Name="FilterToggleButton" Content="Filters ▾" Width="90" Click="FilterToggleButton_Click"/>
             <TextBlock Text="Sort:" VerticalAlignment="Center" Margin="0,0,6,0"/>
             <ComboBox x:Name="SortModeCombo" Width="120" SelectionChanged="SortModeCombo_SelectionChanged">
                 <ComboBoxItem Content="Flat"/>
@@ -28,6 +26,19 @@
             <Button x:Name="SelectAllButton" Content="Select All" Width="90" Margin="12,0,6,0" Click="SelectAllButton_Click"/>
             <Button x:Name="SelectNoneButton" Content="Select None" Width="90" Click="SelectNoneButton_Click"/>
         </StackPanel>
+        <Border x:Name="FilterPanel" Grid.Row="0" Margin="0,32,0,0" Background="WhiteSmoke" BorderBrush="Gray" BorderThickness="1" Padding="8" Visibility="Collapsed">
+            <StackPanel Orientation="Horizontal">
+                <TextBlock Text="Status:" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                <CheckBox x:Name="FilterLinked" Content="Linked" IsChecked="True" Margin="0,0,8,0" Checked="FilterStatus_Changed" Unchecked="FilterStatus_Changed"/>
+                <CheckBox x:Name="FilterOutdated" Content="Outdated" IsChecked="True" Margin="0,0,8,0" Checked="FilterStatus_Changed" Unchecked="FilterStatus_Changed"/>
+                <CheckBox x:Name="FilterMissing" Content="Missing" IsChecked="True" Margin="0,0,12,0" Checked="FilterStatus_Changed" Unchecked="FilterStatus_Changed"/>
+                <TextBlock Text="Category:" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                <CheckBox x:Name="FilterEquipment" Content="Equipment" IsChecked="True" Margin="0,0,6,0" Checked="FilterStatus_Changed" Unchecked="FilterStatus_Changed"/>
+                <CheckBox x:Name="FilterCircuit" Content="Circuit" IsChecked="True" Margin="0,0,6,0" Checked="FilterStatus_Changed" Unchecked="FilterStatus_Changed"/>
+                <CheckBox x:Name="FilterDevice" Content="Device" IsChecked="True" Margin="0,0,6,0" Checked="FilterStatus_Changed" Unchecked="FilterStatus_Changed"/>
+                <CheckBox x:Name="FilterSpare" Content="Spare/Space" IsChecked="True" Checked="FilterStatus_Changed" Unchecked="FilterStatus_Changed"/>
+            </StackPanel>
+        </Border>
 
         <Grid Grid.Row="1">
             <Grid.ColumnDefinitions>
@@ -45,7 +56,7 @@
                                     <ColumnDefinition Width="*"/>
                                 </Grid.ColumnDefinitions>
                                 <CheckBox Grid.Column="0" Width="16" Margin="2,0,2,0" IsChecked="{Binding is_checked}" Click="ItemCheckBox_Click" VerticalAlignment="Center" HorizontalAlignment="Left" Focusable="False"/>
-                                <TextBlock Grid.Column="1" Text="{Binding status_symbol}" Foreground="{Binding status_brush}" VerticalAlignment="Center"/>
+                                <TextBlock Grid.Column="1" Text="{Binding kind_symbol}" Foreground="{Binding status_brush}" VerticalAlignment="Center"/>
                                 <TextBlock Grid.Column="2" Text="{Binding display_text}" VerticalAlignment="Center"/>
                             </Grid>
                         </DataTemplate>

--- a/CEDLib.lib/UIClasses/SyncOneLineWindow.xaml
+++ b/CEDLib.lib/UIClasses/SyncOneLineWindow.xaml
@@ -15,21 +15,25 @@
 
         <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,10">
             <TextBlock Text="Search:" VerticalAlignment="Center" Margin="0,0,6,0"/>
-            <TextBox x:Name="SearchBox" Width="280" TextChanged="SearchBox_TextChanged"/>
-            <TextBlock Text="Legend:" VerticalAlignment="Center" Margin="20,0,6,0"/>
-            <TextBlock Text="●" Foreground="Green" VerticalAlignment="Center" Margin="0,0,4,0"/>
-            <TextBlock Text="Linked" VerticalAlignment="Center" Margin="0,0,12,0"/>
-            <TextBlock Text="●" Foreground="Orange" VerticalAlignment="Center" Margin="0,0,4,0"/>
-            <TextBlock Text="Outdated" VerticalAlignment="Center" Margin="0,0,12,0"/>
-            <TextBlock Text="●" Foreground="Red" VerticalAlignment="Center" Margin="0,0,4,0"/>
-            <TextBlock Text="Missing" VerticalAlignment="Center"/>
+            <TextBox x:Name="SearchBox" Width="220" TextChanged="SearchBox_TextChanged"/>
+            <TextBlock Text="Status:" VerticalAlignment="Center" Margin="12,0,6,0"/>
+            <CheckBox x:Name="FilterLinked" Content="Linked" IsChecked="True" Margin="0,0,8,0" Checked="FilterStatus_Changed" Unchecked="FilterStatus_Changed"/>
+            <CheckBox x:Name="FilterOutdated" Content="Outdated" IsChecked="True" Margin="0,0,8,0" Checked="FilterStatus_Changed" Unchecked="FilterStatus_Changed"/>
+            <CheckBox x:Name="FilterMissing" Content="Missing" IsChecked="True" Margin="0,0,12,0" Checked="FilterStatus_Changed" Unchecked="FilterStatus_Changed"/>
+            <TextBlock Text="Sort:" VerticalAlignment="Center" Margin="0,0,6,0"/>
+            <ComboBox x:Name="SortModeCombo" Width="120" SelectionChanged="SortModeCombo_SelectionChanged">
+                <ComboBoxItem Content="Flat"/>
+                <ComboBoxItem Content="Tree"/>
+            </ComboBox>
+            <Button x:Name="SelectAllButton" Content="Select All" Width="90" Margin="12,0,6,0" Click="SelectAllButton_Click"/>
+            <Button x:Name="SelectNoneButton" Content="Select None" Width="90" Click="SelectNoneButton_Click"/>
         </StackPanel>
 
         <GroupBox Grid.Row="1" Header="Model Elements">
-            <ListBox x:Name="ElementsList" Margin="5">
+            <ListBox x:Name="ElementsList" Margin="5" SelectionMode="Extended">
                 <ListBox.ItemTemplate>
                     <DataTemplate>
-                        <CheckBox IsChecked="{Binding is_checked}">
+                        <CheckBox IsChecked="{Binding is_checked}" Click="ItemCheckBox_Click">
                             <StackPanel Orientation="Horizontal">
                                 <TextBlock Text="{Binding status_symbol}" Foreground="{Binding status_brush}" Margin="0,0,6,0"/>
                                 <TextBlock Text="{Binding display_text}"/>
@@ -50,22 +54,22 @@
 
             <StackPanel Grid.Column="0" Margin="0,0,8,0">
                 <TextBlock Text="Detail Item Family" Margin="0,0,0,4"/>
-                <ComboBox x:Name="DetailFamilyCombo" SelectionChanged="DetailFamilyCombo_SelectionChanged"/>
+                <ComboBox x:Name="DetailFamilyCombo" DisplayMemberPath="Name" SelectionChanged="DetailFamilyCombo_SelectionChanged"/>
             </StackPanel>
 
             <StackPanel Grid.Column="1" Margin="0,0,8,0">
                 <TextBlock Text="Detail Item Type" Margin="0,0,0,4"/>
-                <ComboBox x:Name="DetailTypeCombo"/>
+                <ComboBox x:Name="DetailTypeCombo" DisplayMemberPath="Name"/>
             </StackPanel>
 
             <StackPanel Grid.Column="2" Margin="0,0,8,0">
                 <TextBlock Text="Tag Family (Optional)" Margin="0,0,0,4"/>
-                <ComboBox x:Name="TagFamilyCombo" SelectionChanged="TagFamilyCombo_SelectionChanged"/>
+                <ComboBox x:Name="TagFamilyCombo" DisplayMemberPath="Name" SelectionChanged="TagFamilyCombo_SelectionChanged"/>
             </StackPanel>
 
             <StackPanel Grid.Column="3">
                 <TextBlock Text="Tag Type" Margin="0,0,0,4"/>
-                <ComboBox x:Name="TagTypeCombo"/>
+                <ComboBox x:Name="TagTypeCombo" DisplayMemberPath="Name"/>
             </StackPanel>
         </Grid>
 

--- a/CEDLib.lib/UIClasses/SyncOneLineWindow.xaml
+++ b/CEDLib.lib/UIClasses/SyncOneLineWindow.xaml
@@ -26,16 +26,16 @@
             <Button x:Name="SelectAllButton" Content="Select All" Width="90" Margin="12,0,6,0" Click="SelectAllButton_Click"/>
             <Button x:Name="SelectNoneButton" Content="Select None" Width="90" Click="SelectNoneButton_Click"/>
         </StackPanel>
-        <Border x:Name="FilterPanel" Grid.Row="0" Margin="0,32,0,0" Background="WhiteSmoke" BorderBrush="Gray" BorderThickness="1" Padding="8" Visibility="Collapsed">
-            <StackPanel Orientation="Horizontal">
-                <TextBlock Text="Status:" VerticalAlignment="Center" Margin="0,0,6,0"/>
-                <CheckBox x:Name="FilterLinked" Content="Linked" IsChecked="True" Margin="0,0,8,0" Checked="FilterStatus_Changed" Unchecked="FilterStatus_Changed"/>
-                <CheckBox x:Name="FilterOutdated" Content="Outdated" IsChecked="True" Margin="0,0,8,0" Checked="FilterStatus_Changed" Unchecked="FilterStatus_Changed"/>
-                <CheckBox x:Name="FilterMissing" Content="Missing" IsChecked="True" Margin="0,0,12,0" Checked="FilterStatus_Changed" Unchecked="FilterStatus_Changed"/>
-                <TextBlock Text="Category:" VerticalAlignment="Center" Margin="0,0,6,0"/>
-                <CheckBox x:Name="FilterEquipment" Content="Equipment" IsChecked="True" Margin="0,0,6,0" Checked="FilterStatus_Changed" Unchecked="FilterStatus_Changed"/>
-                <CheckBox x:Name="FilterCircuit" Content="Circuit" IsChecked="True" Margin="0,0,6,0" Checked="FilterStatus_Changed" Unchecked="FilterStatus_Changed"/>
-                <CheckBox x:Name="FilterDevice" Content="Device" IsChecked="True" Margin="0,0,6,0" Checked="FilterStatus_Changed" Unchecked="FilterStatus_Changed"/>
+        <Border x:Name="FilterPanel" Grid.Row="0" Margin="0,32,0,0" Background="WhiteSmoke" BorderBrush="Gray" BorderThickness="1" Padding="8" Visibility="Collapsed" HorizontalAlignment="Left">
+            <StackPanel>
+                <TextBlock Text="Status" FontWeight="Bold" Margin="0,0,0,4"/>
+                <CheckBox x:Name="FilterLinked" Content="Linked" IsChecked="True" Margin="0,0,0,2" Checked="FilterStatus_Changed" Unchecked="FilterStatus_Changed"/>
+                <CheckBox x:Name="FilterOutdated" Content="Outdated" IsChecked="True" Margin="0,0,0,2" Checked="FilterStatus_Changed" Unchecked="FilterStatus_Changed"/>
+                <CheckBox x:Name="FilterMissing" Content="Missing" IsChecked="True" Margin="0,0,0,8" Checked="FilterStatus_Changed" Unchecked="FilterStatus_Changed"/>
+                <TextBlock Text="Category" FontWeight="Bold" Margin="0,0,0,4"/>
+                <CheckBox x:Name="FilterEquipment" Content="Equipment" IsChecked="True" Margin="0,0,0,2" Checked="FilterStatus_Changed" Unchecked="FilterStatus_Changed"/>
+                <CheckBox x:Name="FilterCircuit" Content="Circuit" IsChecked="True" Margin="0,0,0,2" Checked="FilterStatus_Changed" Unchecked="FilterStatus_Changed"/>
+                <CheckBox x:Name="FilterDevice" Content="Device" IsChecked="True" Margin="0,0,0,2" Checked="FilterStatus_Changed" Unchecked="FilterStatus_Changed"/>
                 <CheckBox x:Name="FilterSpare" Content="Spare/Space" IsChecked="True" Checked="FilterStatus_Changed" Unchecked="FilterStatus_Changed"/>
             </StackPanel>
         </Border>
@@ -52,12 +52,10 @@
                             <Grid>
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="22"/>
-                                    <ColumnDefinition Width="22"/>
                                     <ColumnDefinition Width="*"/>
                                 </Grid.ColumnDefinitions>
                                 <CheckBox Grid.Column="0" Width="16" Margin="2,0,2,0" IsChecked="{Binding is_checked}" Click="ItemCheckBox_Click" VerticalAlignment="Center" HorizontalAlignment="Left" Focusable="False"/>
-                                <TextBlock Grid.Column="1" Text="{Binding kind_symbol}" Foreground="{Binding status_brush}" VerticalAlignment="Center"/>
-                                <TextBlock Grid.Column="2" Text="{Binding display_text}" VerticalAlignment="Center"/>
+                                <TextBlock Grid.Column="1" Text="{Binding display_text}" Foreground="{Binding status_brush}" VerticalAlignment="Center"/>
                             </Grid>
                         </DataTemplate>
                     </ListBox.ItemTemplate>


### PR DESCRIPTION
### Motivation
- Replace the fragile, ad-hoc Sync One-Line script with a more robust, maintainable workflow that tracks associations by element ids. 
- Provide a user-friendly UI for selecting model elements, showing status (linked/outdated/missing), searching, and multi-selecting for create/sync operations. 
- Make tree-building and sync logic reusable so it can be consumed by other tools and support syncing from devices/fixtures to detail items.

### Description
- Added a reusable sync service `OneLineSyncService` in `CEDLib.lib/CEDElectrical/Domain/one_line_sync.py` that builds associations by element ids, computes status (`missing`/`outdated`/`linked`), syncs parameters, and can create detail items. 
- Extracted tree-building logic into `CEDLib.lib/CEDElectrical/Domain/one_line_tree.py` with `build_system_tree()` and `TreeNode`/`TreeBranch` classes for reuse in UI and calculations. 
- Implemented a WPF UI in `CEDLib.lib/UIClasses/SyncOneLineWindow.xaml` and `SyncOneLineWindow.py` to display searchable, multi-select list items with status symbols and to choose detail/tag families and types. 
- Updated `Sync One Line.pushbutton/script.py` to use the new service and UI, and refactored the `OneLine22` test script to import `build_system_tree` from the new tree module.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694aa2d7599c8326882f543e959f0677)