### PR TITLE
SetPipeSystem: Fix plan routing and post-divide system targeting

### DIFF
--- a/AE pyTools.extension/AE pyTools.Tab/Mechanical.panel/Piping.pulldown/SetPipeSystem.pushbutton/script.py
+++ b/AE pyTools.extension/AE pyTools.Tab/Mechanical.panel/Piping.pulldown/SetPipeSystem.pushbutton/script.py
@@ -1054,7 +1054,7 @@ def _get_single_open_pipe_connector(pipe):
     return None
 
 
-def _create_short_pipe_from_open_connector(pipe, open_conn, target_system_type, created_stub_ids=None):
+def _create_short_pipe_from_open_connector(pipe, open_conn, target_system_type):
     length_ft = 0.5 / 12.0
 
     try:
@@ -1123,12 +1123,6 @@ def _create_short_pipe_from_open_connector(pipe, open_conn, target_system_type, 
             _set_unique_mep_system_name(new_sys, target_system_type)
     except:
         pass
-
-    if created_stub_ids is not None:
-        try:
-            created_stub_ids.append(stub.Id.IntegerValue)
-        except:
-            pass
 
     logger.info("Created short pipe stub {} from {}".format(output.linkify(stub.Id), output.linkify(pipe.Id)))
     return stub
@@ -1263,7 +1257,7 @@ def _create_open_branch_stubs_from_selection(pipes, target_system_type):
             pass
 
     if not selected_pipe_ids:
-        return 0
+        return []
 
     open_connectors = []
     seen = set()
@@ -1316,8 +1310,24 @@ def _create_open_branch_stubs_from_selection(pipes, target_system_type):
             pass
 
     created_stub_ids = []
+    failed_count = 0
+
     for pipe, conn in open_connectors:
-        _create_short_pipe_from_open_connector(pipe, conn, target_system_type, created_stub_ids)
+        stub = _create_short_pipe_from_open_connector(pipe, conn, target_system_type)
+        if stub:
+            try:
+                created_stub_ids.append(stub.Id.IntegerValue)
+            except:
+                pass
+        else:
+            failed_count += 1
+            try:
+                logger.info('Open-branch stub creation failed for pipe {}.'.format(output.linkify(pipe.Id)))
+            except:
+                logger.info('Open-branch stub creation failed for a selected pipe.')
+
+    if failed_count > 0:
+        logger.info('Open-branch stub summary -> created: {}, failed: {}'.format(len(created_stub_ids), failed_count))
 
     return created_stub_ids
 

--- a/AE pyTools.extension/AE pyTools.Tab/Mechanical.panel/Piping.pulldown/SetPipeSystem.pushbutton/script.py
+++ b/AE pyTools.extension/AE pyTools.Tab/Mechanical.panel/Piping.pulldown/SetPipeSystem.pushbutton/script.py
@@ -361,6 +361,7 @@ def _collect_eligible_connectors_for_undefined_system(pipes):
 
     con_set = DB.ConnectorSet()
     seen_keys = set()
+    fixture_owner_added = set()
 
     while queue:
         el = queue.pop(0)
@@ -372,19 +373,6 @@ def _collect_eligible_connectors_for_undefined_system(pipes):
         if elid in visited:
             continue
         visited.add(elid)
-
-        is_fixture = _is_plumbing_fixture_owner(el)
-
-        # Fixtures are typically endpoint owners; include their piping connectors.
-        if is_fixture:
-            for c in iter_piping_connectors(el):
-                key = _connector_key(c)
-                if key not in seen_keys:
-                    try:
-                        con_set.Insert(c)
-                        seen_keys.add(key)
-                    except:
-                        pass
 
         for c in iter_piping_connectors(el):
             try:
@@ -406,9 +394,24 @@ def _collect_eligible_connectors_for_undefined_system(pipes):
                     queue.append(other_owner)
                     queued.add(other_id)
 
-                # If the neighboring owner is a fixture or tee-like element,
-                # add only this specific boundary connector.
-                if _is_plumbing_fixture_owner(other_owner) or _owner_has_three_plus_piping_connectors(other_owner):
+                # If neighboring owner is eligible, add boundary connector only.
+                # Fixture rule: add only the first connected fixture connector we hit
+                # per fixture owner to avoid grabbing unused fixture ports.
+                if _is_plumbing_fixture_owner(other_owner):
+                    if other_id in fixture_owner_added:
+                        continue
+
+                    key = _connector_key(other)
+                    if key not in seen_keys:
+                        try:
+                            con_set.Insert(other)
+                            seen_keys.add(key)
+                            fixture_owner_added.add(other_id)
+                        except:
+                            pass
+                    continue
+
+                if _owner_has_three_plus_piping_connectors(other_owner):
                     key = _connector_key(other)
                     if key not in seen_keys:
                         try:
@@ -997,57 +1000,63 @@ def main():
     eval_data = _evaluate_selection(elements, pipes, saved_pairs, affected_system_ids)
     _print_plan(eval_data)
 
-    # --------------------------------------------------------
-    # PLAN A: Existing systems present (do NOT break this flow)
-    # Disconnect -> Divide -> Set system type on systems -> Reconnect
-    # --------------------------------------------------------
-    if eval_data["has_existing_systems"]:
-        if eval_data["has_boundary_pairs"]:
-            _run_tx("SetPipeSystem - Disconnect boundary", disconnect_pairs_now, saved_pairs)
+    with DB.TransactionGroup(doc, "SetPipeSystem - Apply Plan") as tg:
+        tg.Start()
 
-        # Divide only if we actually have affected system ids
-        if len(eval_data["affected_system_ids"]) > 0:
-            new_affected = _run_tx("SetPipeSystem - Divide affected systems",
-                                   divide_affected_systems,
-                                   eval_data["affected_system_ids"])
-            eval_data["affected_system_ids"] = new_affected
+        # --------------------------------------------------------
+        # PLAN A: Existing systems present (do NOT break this flow)
+        # Disconnect -> Divide -> Set system type on systems -> Reconnect
+        # --------------------------------------------------------
+        if eval_data["has_existing_systems"]:
+            if eval_data["has_boundary_pairs"]:
+                _run_tx("SetPipeSystem - Disconnect boundary", disconnect_pairs_now, saved_pairs)
 
-        # Re-collect system ids from pipes post-divide (safer than relying on affected ids)
-        sys_ids_after = _collect_pipe_system_ids_from_connectors(pipes)
-        _run_tx("SetPipeSystem - Set type on existing systems",
-                _set_type_on_system_ids,
-                sys_ids_after,
-                target_system_type)
+            # Divide only if we actually have affected system ids
+            if len(eval_data["affected_system_ids"]) > 0:
+                new_affected = _run_tx("SetPipeSystem - Divide affected systems",
+                                       divide_affected_systems,
+                                       eval_data["affected_system_ids"])
+                eval_data["affected_system_ids"] = new_affected
 
-        if eval_data["has_boundary_pairs"]:
-            _run_tx("SetPipeSystem - Reconnect boundary", reconnect_pairs, saved_pairs)
+            # Re-collect system ids from pipes post-divide (safer than relying on affected ids)
+            sys_ids_after = _collect_pipe_system_ids_from_connectors(pipes)
+            _run_tx("SetPipeSystem - Set type on existing systems",
+                    _set_type_on_system_ids,
+                    sys_ids_after,
+                    target_system_type)
 
-        print("\n=== COMPLETE (PLAN A) ===\n")
-        return
+            if eval_data["has_boundary_pairs"]:
+                _run_tx("SetPipeSystem - Reconnect boundary", reconnect_pairs, saved_pairs)
 
-    # --------------------------------------------------------
-    # PLAN B: No systems on selected pipes (undefined mode)
-    #
-    # - If eligible (tee/fixture/etc.), create a new system and
-    #   add only eligible connectors (fixture / tee-like connectors).
-    #
-    # - If NOT eligible (isolated linear runs), do nothing.
-    # --------------------------------------------------------
-    if not eval_data["undefined_network_eligible"]:
-        print("\nUndefined network is not eligible for system assignment (matches Systemizer behavior).")
-        print("No changes made.")
-        print("\n=== COMPLETE (PLAN B - NOOP) ===\n")
-        return
+            tg.Assimilate()
+            print("\n=== COMPLETE (PLAN A) ===\n")
+            return
 
-    created = _run_tx("SetPipeSystem - Create system from eligible connectors (undefined)",
-                      _create_system_from_eligible_connectors,
-                      pipes,
-                      target_system_type)
+        # --------------------------------------------------------
+        # PLAN B: No systems on selected pipes (undefined mode)
+        #
+        # - If eligible (tee/fixture/etc.), create a new system and
+        #   add only eligible connectors (fixture / tee-like connectors).
+        #
+        # - If NOT eligible (isolated linear runs), do nothing.
+        # --------------------------------------------------------
+        if not eval_data["undefined_network_eligible"]:
+            print("\nUndefined network is not eligible for system assignment (matches Systemizer behavior).")
+            print("No changes made.")
+            tg.Assimilate()
+            print("\n=== COMPLETE (PLAN B - NOOP) ===\n")
+            return
 
-    if not created:
-        logger.warning("Undefined system creation did not assign any connectors.")
+        created = _run_tx("SetPipeSystem - Create system from eligible connectors (undefined)",
+                          _create_system_from_eligible_connectors,
+                          pipes,
+                          target_system_type)
 
-    print("\n=== COMPLETE (PLAN B) ===\n")
+        if not created:
+            logger.warning("Undefined system creation did not assign any connectors.")
+
+        tg.Assimilate()
+        print("\n=== COMPLETE (PLAN B) ===\n")
 
 
 if __name__ == "__main__":

--- a/AE pyTools.extension/AE pyTools.Tab/Mechanical.panel/Piping.pulldown/SetPipeSystem.pushbutton/script.py
+++ b/AE pyTools.extension/AE pyTools.Tab/Mechanical.panel/Piping.pulldown/SetPipeSystem.pushbutton/script.py
@@ -15,8 +15,12 @@ output.close_others()
 VERBOSE_LOGGING = False
 
 try:
-    if hasattr(logger, "set_verbose_mode"):
-        logger.set_verbose_mode(VERBOSE_LOGGING)
+    if VERBOSE_LOGGING:
+        if hasattr(logger, "set_verbose_mode"):
+            logger.set_verbose_mode()
+    else:
+        if hasattr(logger, "reset_level"):
+            logger.reset_level()
 except Exception:
     pass
 
@@ -174,15 +178,26 @@ def get_user_selection():
     return elements
 
 
-def get_selected_pipes(elements):
+def get_selected_network_mode(elements):
     pipes = [el for el in elements if isinstance(el, DBP.Pipe)]
+    ducts = [el for el in elements if isinstance(el, DBM.Duct)]
+
     logger.info("Selected element count: {}".format(len(elements)))
     logger.info("Selected pipe count: {}".format(len(pipes)))
-    if not pipes:
-        logger.info("No pipes selected. Exiting (Victaulic behavior).")
+    logger.info("Selected duct count: {}".format(len(ducts)))
+
+    if pipes and ducts:
+        logger.warning("Mixed selection detected (pipes + ducts). Please select one or the other.")
         script.exit()
 
-    return pipes
+    if pipes:
+        return "piping", pipes
+
+    if ducts:
+        return "duct", ducts
+
+    logger.info("No pipes or ducts selected. Exiting.")
+    script.exit()
 
 
 # ============================================================
@@ -217,6 +232,34 @@ def pick_piping_system_type():
     return type_map[selected]
 
 
+def pick_duct_system_type():
+    system_types = (
+        DB.FilteredElementCollector(doc)
+        .OfClass(DBM.DuctSystemType)
+        .ToElements()
+    )
+
+    type_map = {}
+    for st in system_types:
+        try:
+            name = DB.Element.Name.__get__(st)
+        except:
+            name = None
+        if name:
+            type_map[name] = st
+
+    selected = forms.SelectFromList.show(
+        sorted(type_map.keys()),
+        title="Select Duct System Type",
+        multiselect=False
+    )
+
+    if not selected:
+        script.exit()
+
+    return type_map[selected]
+
+
 # ============================================================
 # CONNECTOR HELPERS
 # ============================================================
@@ -233,6 +276,95 @@ def iter_piping_connectors(el):
                 yield c
         except:
             continue
+
+
+def iter_duct_connectors(el):
+    try:
+        cm = get_connector_manager(el)
+    except NoConnectorManagerError:
+        return
+
+    for c in cm.Connectors:
+        try:
+            if c.Domain == DB.Domain.DomainHvac:
+                yield c
+        except:
+            continue
+
+
+def _get_duct_system(duct):
+    try:
+        sys = duct.MEPSystem
+        if sys:
+            return sys
+    except:
+        pass
+    return None
+
+
+def _get_duct_system_preop(duct):
+    sys = _get_duct_system(duct)
+    if sys:
+        return sys
+
+    for c in iter_duct_connectors(duct):
+        try:
+            sys = c.MEPSystem
+        except:
+            sys = None
+        if sys:
+            return sys
+
+    return None
+
+
+def _collect_duct_system_ids_preop(ducts):
+    sys_ids = set()
+    for d in ducts:
+        sys = _get_duct_system_preop(d)
+        if sys:
+            try:
+                sys_ids.add(sys.Id.IntegerValue)
+            except:
+                pass
+    return sys_ids
+
+
+def _collect_duct_system_ids_from_connectors(ducts):
+    sys_ids = set()
+    for d in ducts:
+        for c in iter_duct_connectors(d):
+            try:
+                sys = c.MEPSystem
+            except:
+                sys = None
+            if sys:
+                try:
+                    sys_ids.add(sys.Id.IntegerValue)
+                except:
+                    pass
+    return sys_ids
+
+
+def _set_duct_system_type_param(ducts, target_system_type):
+    logger.info("\n--- Setting duct system type param ---")
+    ok = 0
+    fail = 0
+
+    for d in ducts:
+        try:
+            param = d.get_Parameter(DB.BuiltInParameter.RBS_DUCT_SYSTEM_TYPE_PARAM)
+            if not param:
+                raise Exception("Duct has no RBS_DUCT_SYSTEM_TYPE_PARAM.")
+            param.Set(target_system_type.Id)
+            ok += 1
+            logger.info("Set system type on duct {}".format(output.linkify(d.Id)))
+        except Exception as ex:
+            fail += 1
+            logger.error("Failed setting system type on duct {}: {}".format(d.Id, ex))
+
+    logger.info("Duct-param results -> ok: {}, fail: {}".format(ok, fail))
+    return ok, fail
 
 
 def pick_disconnect_driver(conn_a, conn_b):
@@ -450,6 +582,7 @@ def _add_eligible_connectors_to_system(new_sys, connectors):
 
     added = 0
     skipped = 0
+    first_skip = None
 
     for conn in connectors:
         one = DB.ConnectorSet()
@@ -464,7 +597,15 @@ def _add_eligible_connectors_to_system(new_sys, connectors):
             added += 1
         except Exception as ex:
             skipped += 1
-            logger.warning('Skipping connector during undefined add ({}): {}'.format(output.linkify(new_sys.Id), ex))
+            if first_skip is None:
+                first_skip = ex
+
+    if skipped > 0:
+        logger.warning('Skipped {} connector(s) during undefined add on {}. First error: {}'.format(
+            skipped,
+            output.linkify(new_sys.Id),
+            first_skip
+        ))
 
     return added, skipped
 
@@ -941,8 +1082,8 @@ def _set_type_on_system(sys_el, target_system_type):
         return False
 
 
-def _set_type_on_system_ids(system_ids, target_system_type):
-    logger.info("\n--- Setting system type on isolated systems (existing systems) ---")
+def _set_type_on_system_ids(system_ids, target_system_type, system_class, label):
+    logger.info("\n--- Setting system type on isolated {} systems ---".format(label))
     ok = 0
     fail = 0
     seen = set()
@@ -955,7 +1096,7 @@ def _set_type_on_system_ids(system_ids, target_system_type):
         sys_el = doc.GetElement(DB.ElementId(sid))
         if not sys_el:
             continue
-        if not isinstance(sys_el, DBP.PipingSystem):
+        if not isinstance(sys_el, system_class):
             continue
 
         if _set_type_on_system(sys_el, target_system_type):
@@ -1077,73 +1218,100 @@ def _print_plan(eval_data):
 # ============================================================
 
 def main():
-    logger.info("\n=== SET PIPING SYSTEM (EVALUATE -> APPLY PLAN) ===\n")
+    logger.info("\n=== SET MEP SYSTEM (EVALUATE -> APPLY PLAN) ===\n")
     elements = get_user_selection()
-    pipes = get_selected_pipes(elements)
-    target_system_type = pick_piping_system_type()
+    mode, selected_curves = get_selected_network_mode(elements)
 
-    # Always collect boundary pairs up front (cheap + used in both plans)
-    selected_ids, saved_pairs, affected_system_ids = collect_boundary_work(elements)
+    if mode == "piping":
+        pipes = selected_curves
+        target_system_type = pick_piping_system_type()
 
-    eval_data = _evaluate_selection(elements, pipes, saved_pairs, affected_system_ids)
-    _print_plan(eval_data)
+        selected_ids, saved_pairs, affected_system_ids = collect_boundary_work(elements)
 
-    with DB.TransactionGroup(doc, "SetPipeSystem - Apply Plan") as tg:
+        eval_data = _evaluate_selection(elements, pipes, saved_pairs, affected_system_ids)
+        _print_plan(eval_data)
+
+        with DB.TransactionGroup(doc, "SetPipeSystem - Apply Plan") as tg:
+            tg.Start()
+
+            if eval_data["has_existing_systems"]:
+                if eval_data["has_boundary_pairs"]:
+                    _run_tx("SetPipeSystem - Disconnect boundary", disconnect_pairs_now, saved_pairs)
+
+                if len(eval_data["affected_system_ids"]) > 0:
+                    new_affected = _run_tx("SetPipeSystem - Divide affected systems",
+                                           divide_affected_systems,
+                                           eval_data["affected_system_ids"])
+                    eval_data["affected_system_ids"] = new_affected
+
+                sys_ids_after = _collect_pipe_system_ids_from_connectors(pipes)
+                _run_tx("SetPipeSystem - Set type on existing systems",
+                        _set_type_on_system_ids,
+                        sys_ids_after,
+                        target_system_type,
+                        DBP.PipingSystem,
+                        "piping")
+
+                if eval_data["has_boundary_pairs"]:
+                    _run_tx("SetPipeSystem - Reconnect boundary", reconnect_pairs, saved_pairs)
+
+                tg.Assimilate()
+                logger.info("\n=== COMPLETE (PIPING PLAN A) ===\n")
+                return
+
+            if not eval_data["undefined_network_eligible"]:
+                logger.info("\nUndefined network is not eligible for system assignment (matches Systemizer behavior).")
+                logger.info("No changes made.")
+                tg.Assimilate()
+                logger.info("\n=== COMPLETE (PIPING PLAN B - NOOP) ===\n")
+                return
+
+            created = _run_tx("SetPipeSystem - Create system from eligible connectors (undefined)",
+                              _create_system_from_eligible_connectors,
+                              pipes,
+                              target_system_type)
+
+            if not created:
+                logger.warning("Undefined system creation did not assign any connectors.")
+
+            tg.Assimilate()
+            logger.info("\n=== COMPLETE (PIPING PLAN B) ===\n")
+            return
+
+    ducts = selected_curves
+    target_system_type = pick_duct_system_type()
+    sys_ids_pre = _collect_duct_system_ids_preop(ducts)
+
+    with DB.TransactionGroup(doc, "SetDuctSystem - Apply Plan") as tg:
         tg.Start()
 
-        # --------------------------------------------------------
-        # PLAN A: Existing systems present (do NOT break this flow)
-        # Disconnect -> Divide -> Set system type on systems -> Reconnect
-        # --------------------------------------------------------
-        if eval_data["has_existing_systems"]:
-            if eval_data["has_boundary_pairs"]:
-                _run_tx("SetPipeSystem - Disconnect boundary", disconnect_pairs_now, saved_pairs)
+        if len(sys_ids_pre) > 0:
+            _run_tx("SetDuctSystem - Set type on existing systems",
+                    _set_type_on_system_ids,
+                    sys_ids_pre,
+                    target_system_type,
+                    DBM.MechanicalSystem,
+                    "duct")
+            tg.Assimilate()
+            logger.info("\n=== COMPLETE (DUCT EXISTING) ===\n")
+            return
 
-            # Divide only if we actually have affected system ids
-            if len(eval_data["affected_system_ids"]) > 0:
-                new_affected = _run_tx("SetPipeSystem - Divide affected systems",
-                                       divide_affected_systems,
-                                       eval_data["affected_system_ids"])
-                eval_data["affected_system_ids"] = new_affected
+        _run_tx("SetDuctSystem - Set type via duct parameter",
+                _set_duct_system_type_param,
+                ducts,
+                target_system_type)
 
-            # Re-collect system ids from pipes post-divide (safer than relying on affected ids)
-            sys_ids_after = _collect_pipe_system_ids_from_connectors(pipes)
-            _run_tx("SetPipeSystem - Set type on existing systems",
+        sys_ids_after = _collect_duct_system_ids_from_connectors(ducts)
+        if len(sys_ids_after) > 0:
+            _run_tx("SetDuctSystem - Name resulting systems",
                     _set_type_on_system_ids,
                     sys_ids_after,
-                    target_system_type)
-
-            if eval_data["has_boundary_pairs"]:
-                _run_tx("SetPipeSystem - Reconnect boundary", reconnect_pairs, saved_pairs)
-
-            tg.Assimilate()
-            logger.info("\n=== COMPLETE (PLAN A) ===\n")
-            return
-
-        # --------------------------------------------------------
-        # PLAN B: No systems on selected pipes (undefined mode)
-        #
-        # - If eligible (tee/fixture/etc.), create a new system and
-        #   add only eligible connectors (fixture / tee-like connectors).
-        #
-        # - If NOT eligible (isolated linear runs), do nothing.
-        # --------------------------------------------------------
-        if not eval_data["undefined_network_eligible"]:
-            logger.info("\nUndefined network is not eligible for system assignment (matches Systemizer behavior).")
-            logger.info("No changes made.")
-            tg.Assimilate()
-            logger.info("\n=== COMPLETE (PLAN B - NOOP) ===\n")
-            return
-
-        created = _run_tx("SetPipeSystem - Create system from eligible connectors (undefined)",
-                          _create_system_from_eligible_connectors,
-                          pipes,
-                          target_system_type)
-
-        if not created:
-            logger.warning("Undefined system creation did not assign any connectors.")
+                    target_system_type,
+                    DBM.MechanicalSystem,
+                    "duct")
 
         tg.Assimilate()
-        logger.info("\n=== COMPLETE (PLAN B) ===\n")
+        logger.info("\n=== COMPLETE (DUCT PARAM) ===\n")
+
 if __name__ == "__main__":
     main()

--- a/AE pyTools.extension/AE pyTools.Tab/Mechanical.panel/Piping.pulldown/SetPipeSystem.pushbutton/script.py
+++ b/AE pyTools.extension/AE pyTools.Tab/Mechanical.panel/Piping.pulldown/SetPipeSystem.pushbutton/script.py
@@ -39,18 +39,19 @@ def xyz_equal(a, b, tol):
         return False
 
 
-def find_connector_by_origin(el, origin, tol):
+def find_connector_by_origin(el, origin, tol, connector_iter=None):
     """
-    Find a piping connector on element whose Origin matches within tolerance.
+    Find a connector on element whose Origin matches within tolerance.
     """
-    for c in iter_piping_connectors(el):
+    iterator = connector_iter or iter_piping_connectors
+
+    for c in iterator(el):
         try:
             if xyz_equal(c.Origin, origin, tol):
                 return c
         except:
             continue
     return None
-
 
 def _make_elementid_list(elements):
     ids = List[DB.ElementId]()
@@ -235,7 +236,7 @@ def pick_piping_system_type():
 def pick_duct_system_type():
     system_types = (
         DB.FilteredElementCollector(doc)
-        .OfClass(DBM.DuctSystemType)
+        .OfClass(DBM.MechanicalSystemType)
         .ToElements()
     )
 
@@ -541,10 +542,10 @@ def _collect_eligible_connectors_for_undefined_system(pipes):
                     if other_id in fixture_owner_added:
                         continue
 
-                    key = _connector_key(other)
+                    key = _connector_key(c)
                     if key not in seen_keys:
                         try:
-                            con_set.Insert(other)
+                            con_set.Insert(c)
                             seen_keys.add(key)
                             fixture_owner_added.add(other_id)
                         except:
@@ -703,19 +704,19 @@ def _create_system_from_eligible_connectors(pipes, target_system_type):
 # PHASE 0 — COLLECT BOUNDARY PAIRS + AFFECTED SYSTEM IDS
 # ============================================================
 
-def collect_boundary_work(elements):
+def collect_boundary_work(elements, connector_iter):
     """
     Returns:
       selected_ids: set(int)
       saved_pairs: list(dict) with owner ids + connector origins (for reconnect)
-      affected_system_ids: set(int) piping system ids to divide later
+      affected_system_ids: set(int) system ids to divide later
     """
     selected_ids = set([el.Id.IntegerValue for el in elements])
     saved_pairs = []
     affected_system_ids = set()
 
     logger.info("\n--- Collecting boundary connections ---")
-    # collect systems directly from selected elements
+
     for el in elements:
         try:
             sys = el.MEPSystem
@@ -724,7 +725,7 @@ def collect_boundary_work(elements):
         except:
             pass
 
-        for c in iter_piping_connectors(el):
+        for c in connector_iter(el):
             try:
                 if not c.IsConnected:
                     continue
@@ -745,7 +746,6 @@ def collect_boundary_work(elements):
                 except:
                     continue
 
-                # disconnect only across selection boundary
                 try:
                     if other_owner.Id.IntegerValue in selected_ids:
                         continue
@@ -754,7 +754,6 @@ def collect_boundary_work(elements):
 
                 driver, target = pick_disconnect_driver(c, other)
 
-                # record affected system id BEFORE disconnect (store id only, not object)
                 try:
                     sys = driver.MEPSystem
                     if sys:
@@ -762,7 +761,6 @@ def collect_boundary_work(elements):
                 except:
                     pass
 
-                # record reconnect descriptors BEFORE disconnect
                 try:
                     driver_owner_id = driver.Owner.Id.IntegerValue
                     driver_origin = driver.Origin
@@ -783,18 +781,12 @@ def collect_boundary_work(elements):
                 })
 
     logger.info("Boundary connection pairs found: {}".format(len(saved_pairs)))
-    logger.info("Affected piping system ids: {}".format(len(affected_system_ids)))
+    logger.info("Affected system ids: {}".format(len(affected_system_ids)))
     return selected_ids, saved_pairs, affected_system_ids
 
-
-# ============================================================
-# TX ACTIONS (small, single-purpose)
-# ============================================================
-
-def disconnect_pairs_now(saved_pairs):
+def disconnect_pairs_now(saved_pairs, connector_iter):
     """
-    Disconnect using live connector objects found by origin in the current model state.
-    Note: uses origin matching strategy; do not change unless you replace the pair schema.
+    Disconnect using live connector objects found by origin in current model state.
     """
     logger.info("\n--- Disconnecting boundary pairs ---")
     ok = 0
@@ -809,8 +801,8 @@ def disconnect_pairs_now(saved_pairs):
             logger.warning("Disconnect skip: missing owner element(s).")
             continue
 
-        a_conn = find_connector_by_origin(a_el, pair["a_origin"], tol)
-        b_conn = find_connector_by_origin(b_el, pair["b_origin"], tol)
+        a_conn = find_connector_by_origin(a_el, pair["a_origin"], tol, connector_iter)
+        b_conn = find_connector_by_origin(b_el, pair["b_origin"], tol, connector_iter)
         if not a_conn or not b_conn:
             fail += 1
             logger.warning("Disconnect skip: could not resolve connector(s) by origin.")
@@ -826,7 +818,8 @@ def disconnect_pairs_now(saved_pairs):
             logger.warning("Failed disconnect: {}".format(ex))
 
     logger.info("Disconnect results -> ok: {}, fail: {}".format(ok, fail))
-def divide_affected_systems(affected_system_ids):
+
+def divide_affected_systems(affected_system_ids, system_class):
     logger.info("\n--- Dividing affected systems ---")
     ok = 0
     skip = 0
@@ -850,7 +843,7 @@ def divide_affected_systems(affected_system_ids):
                 skip += 1
                 continue
 
-            if not isinstance(sys_el, DBP.PipingSystem):
+            if not isinstance(sys_el, system_class):
                 skip += 1
                 continue
 
@@ -876,6 +869,7 @@ def divide_affected_systems(affected_system_ids):
 
             ok += 1
             logger.info("Divided system {}".format(output.linkify(DB.ElementId(sid))))
+
             if new_ids:
                 for nid in new_ids:
                     try:
@@ -890,6 +884,7 @@ def divide_affected_systems(affected_system_ids):
     if created_ids:
         logger.info("New systems created by DivideSystem: {}".format(len(created_ids)))
     logger.info("Divide results -> ok: {}, skip: {}, fail: {}".format(ok, skip, fail))
+
     refreshed = set()
     for sid in survived_ids:
         refreshed.add(sid)
@@ -897,7 +892,6 @@ def divide_affected_systems(affected_system_ids):
         refreshed.add(sid)
 
     return refreshed
-
 
 def _get_pipe_system(pipe):
     try:
@@ -1135,7 +1129,7 @@ def _set_pipe_system_type_param(pipes, target_system_type):
     return ok, fail
 
 
-def reconnect_pairs(saved_pairs):
+def reconnect_pairs(saved_pairs, connector_iter):
     logger.info("\n--- Reconnecting boundary pairs ---")
     ok = 0
     fail = 0
@@ -1149,8 +1143,8 @@ def reconnect_pairs(saved_pairs):
             logger.warning("Reconnect skip: missing owner element(s).")
             continue
 
-        a_conn = find_connector_by_origin(a_el, pair["a_origin"], tol)
-        b_conn = find_connector_by_origin(b_el, pair["b_origin"], tol)
+        a_conn = find_connector_by_origin(a_el, pair["a_origin"], tol, connector_iter)
+        b_conn = find_connector_by_origin(b_el, pair["b_origin"], tol, connector_iter)
         if not a_conn or not b_conn:
             fail += 1
             logger.warning("Reconnect skip: could not resolve connector(s) by origin.")
@@ -1165,9 +1159,6 @@ def reconnect_pairs(saved_pairs):
             logger.warning("Failed reconnect: {}".format(ex))
 
     logger.info("Reconnect results -> ok: {}, fail: {}".format(ok, fail))
-# ============================================================
-# TRANSACTION WRAPPERS
-# ============================================================
 
 def _run_tx(tx_name, fn, *args, **kwargs):
     """
@@ -1226,9 +1217,8 @@ def main():
         pipes = selected_curves
         target_system_type = pick_piping_system_type()
 
-        selected_ids, saved_pairs, affected_system_ids = collect_boundary_work(elements)
-
-        eval_data = _evaluate_selection(elements, pipes, saved_pairs, affected_system_ids)
+        selected_ids, saved_pairs, affected_system_ids = collect_boundary_work(pipes, iter_piping_connectors)
+        eval_data = _evaluate_selection(pipes, pipes, saved_pairs, affected_system_ids)
         _print_plan(eval_data)
 
         with DB.TransactionGroup(doc, "SetPipeSystem - Apply Plan") as tg:
@@ -1236,12 +1226,13 @@ def main():
 
             if eval_data["has_existing_systems"]:
                 if eval_data["has_boundary_pairs"]:
-                    _run_tx("SetPipeSystem - Disconnect boundary", disconnect_pairs_now, saved_pairs)
+                    _run_tx("SetPipeSystem - Disconnect boundary", disconnect_pairs_now, saved_pairs, iter_piping_connectors)
 
                 if len(eval_data["affected_system_ids"]) > 0:
                     new_affected = _run_tx("SetPipeSystem - Divide affected systems",
                                            divide_affected_systems,
-                                           eval_data["affected_system_ids"])
+                                           eval_data["affected_system_ids"],
+                                           DBP.PipingSystem)
                     eval_data["affected_system_ids"] = new_affected
 
                 sys_ids_after = _collect_pipe_system_ids_from_connectors(pipes)
@@ -1253,7 +1244,7 @@ def main():
                         "piping")
 
                 if eval_data["has_boundary_pairs"]:
-                    _run_tx("SetPipeSystem - Reconnect boundary", reconnect_pairs, saved_pairs)
+                    _run_tx("SetPipeSystem - Reconnect boundary", reconnect_pairs, saved_pairs, iter_piping_connectors)
 
                 tg.Assimilate()
                 logger.info("\n=== COMPLETE (PIPING PLAN A) ===\n")
@@ -1280,18 +1271,34 @@ def main():
 
     ducts = selected_curves
     target_system_type = pick_duct_system_type()
+
+    selected_ids, saved_pairs, affected_system_ids = collect_boundary_work(ducts, iter_duct_connectors)
     sys_ids_pre = _collect_duct_system_ids_preop(ducts)
 
     with DB.TransactionGroup(doc, "SetDuctSystem - Apply Plan") as tg:
         tg.Start()
 
         if len(sys_ids_pre) > 0:
+            if len(saved_pairs) > 0:
+                _run_tx("SetDuctSystem - Disconnect boundary", disconnect_pairs_now, saved_pairs, iter_duct_connectors)
+
+            if len(affected_system_ids) > 0:
+                _run_tx("SetDuctSystem - Divide affected systems",
+                        divide_affected_systems,
+                        affected_system_ids,
+                        DBM.MechanicalSystem)
+
+            sys_ids_after = _collect_duct_system_ids_from_connectors(ducts)
             _run_tx("SetDuctSystem - Set type on existing systems",
                     _set_type_on_system_ids,
-                    sys_ids_pre,
+                    sys_ids_after,
                     target_system_type,
                     DBM.MechanicalSystem,
                     "duct")
+
+            if len(saved_pairs) > 0:
+                _run_tx("SetDuctSystem - Reconnect boundary", reconnect_pairs, saved_pairs, iter_duct_connectors)
+
             tg.Assimilate()
             logger.info("\n=== COMPLETE (DUCT EXISTING) ===\n")
             return

--- a/AE pyTools.extension/AE pyTools.Tab/Mechanical.panel/Piping.pulldown/SetPipeSystem.pushbutton/script.py
+++ b/AE pyTools.extension/AE pyTools.Tab/Mechanical.panel/Piping.pulldown/SetPipeSystem.pushbutton/script.py
@@ -461,32 +461,6 @@ def _add_eligible_connectors_to_system(new_sys, connectors):
     return added, skipped
 
 
-def _iter_piping_system_types_for_seed(target_system_type):
-    """
-    Yield seed system types with target first, then all other types.
-    This allows fallback seeding when target classification is too strict for
-    the first connector assignment on undefined networks.
-    """
-    yielded = set()
-
-    if target_system_type:
-        try:
-            yielded.add(target_system_type.Id.IntegerValue)
-            yield target_system_type
-        except:
-            pass
-
-    for st in DB.FilteredElementCollector(doc).OfClass(DBP.PipingSystemType).ToElements():
-        try:
-            sid = st.Id.IntegerValue
-        except:
-            continue
-        if sid in yielded:
-            continue
-        yielded.add(sid)
-        yield st
-
-
 def _get_system_type_abbreviation(target_system_type):
     """Get preferred abbreviation token for naming new systems."""
     try:
@@ -742,49 +716,44 @@ def _create_system_from_open_pipe_stub(pipes, target_system_type):
     return True, sys
 
 
-def _seed_undefined_system_with_fallback(connectors, target_system_type, pipes):
+def _seed_undefined_system(connectors, target_system_type, pipes):
     """
-    Try target type first; if connector-domain/classification blocks assignment,
-    try other seed types until at least one selected pipe is actually assigned.
+    Seed undefined system using only the user-selected target system type.
+    If no selected pipes are assigned, delete the created system.
     """
-    for seed_type in _iter_piping_system_types_for_seed(target_system_type):
-        seed_name = None
-        try:
-            seed_name = DB.Element.Name.__get__(seed_type)
-        except:
-            seed_name = str(seed_type.Id.IntegerValue)
+    seed_name = None
+    try:
+        seed_name = DB.Element.Name.__get__(target_system_type)
+    except:
+        seed_name = str(target_system_type.Id.IntegerValue)
 
-        new_sys = _create_empty_piping_system(seed_type)
-        if not new_sys:
-            continue
+    new_sys = _create_empty_piping_system(target_system_type)
+    if not new_sys:
+        return False, None
 
-        added, skipped = _add_eligible_connectors_to_system(new_sys, connectors)
-        print('Undefined seed attempt [{}] -> added: {}, skipped: {}'.format(seed_name, added, skipped))
+    added, skipped = _add_eligible_connectors_to_system(new_sys, connectors)
+    print('Undefined seed attempt [{}] -> added: {}, skipped: {}'.format(seed_name, added, skipped))
 
-        if added > 0:
-            # If we seeded with a non-target type, flip to requested target type now.
-            try:
-                if seed_type.Id.IntegerValue != target_system_type.Id.IntegerValue:
-                    _set_type_on_system(new_sys, target_system_type)
-            except:
-                pass
-
-            sid = new_sys.Id.IntegerValue
-            assigned = _count_selected_pipes_on_system(pipes, sid)
-            if assigned > 0:
-                _set_unique_system_name(new_sys, target_system_type)
-                print('Selected pipes assigned to new system: {}'.format(assigned))
-                return True, new_sys
-
-            logger.warning('Seeded system {} but no selected pipes were assigned. Deleting empty/unrelated system.'.format(output.linkify(new_sys.Id)))
-
-        # No useful assignment for this seed type; delete and try next.
+    if added <= 0:
         try:
             doc.Delete(new_sys.Id)
         except:
             pass
+        return False, None
 
-    return False, None
+    sid = new_sys.Id.IntegerValue
+    assigned = _count_selected_pipes_on_system(pipes, sid)
+    if assigned <= 0:
+        logger.warning('Seeded system {} but no selected pipes were assigned. Deleting system.'.format(output.linkify(new_sys.Id)))
+        try:
+            doc.Delete(new_sys.Id)
+        except:
+            pass
+        return False, None
+
+    _set_unique_system_name(new_sys, target_system_type)
+    print('Selected pipes assigned to new system: {}'.format(assigned))
+    return True, new_sys
 
 
 def _create_system_from_eligible_connectors(pipes, target_system_type):
@@ -809,7 +778,7 @@ def _create_system_from_eligible_connectors(pipes, target_system_type):
     if connector_count == 0:
         return False
 
-    ok, new_sys = _seed_undefined_system_with_fallback(connectors, target_system_type, pipes)
+    ok, new_sys = _seed_undefined_system(connectors, target_system_type, pipes)
     if ok and new_sys:
         print('Created undefined system {}'.format(output.linkify(new_sys.Id)))
         return True

--- a/AE pyTools.extension/AE pyTools.Tab/Mechanical.panel/Piping.pulldown/SetPipeSystem.pushbutton/script.py
+++ b/AE pyTools.extension/AE pyTools.Tab/Mechanical.panel/Piping.pulldown/SetPipeSystem.pushbutton/script.py
@@ -487,10 +487,265 @@ def _iter_piping_system_types_for_seed(target_system_type):
         yield st
 
 
-def _seed_undefined_system_with_fallback(connectors, target_system_type):
+def _get_system_type_abbreviation(target_system_type):
+    """Get preferred abbreviation token for naming new systems."""
+    try:
+        p = target_system_type.LookupParameter("Abbreviation")
+        if p:
+            val = p.AsString()
+            if val:
+                return val.strip()
+    except:
+        pass
+
+    try:
+        p = target_system_type.get_Parameter(DB.BuiltInParameter.RBS_SYSTEM_ABBREVIATION_PARAM)
+        if p:
+            val = p.AsString()
+            if val:
+                return val.strip()
+    except:
+        pass
+
+    try:
+        name = DB.Element.Name.__get__(target_system_type)
+        if name:
+            return name.split()[0]
+    except:
+        pass
+
+    return "SYS"
+
+
+def _collect_used_piping_system_names():
+    names = set()
+    for s in DB.FilteredElementCollector(doc).OfClass(DBP.PipingSystem).ToElements():
+        try:
+            name = DB.Element.Name.__get__(s)
+            if name:
+                names.add(name)
+        except:
+            pass
+    return names
+
+
+def _set_unique_system_name(sys_el, target_system_type):
+    if not sys_el:
+        return False
+
+    used = _collect_used_piping_system_names()
+    try:
+        current_name = DB.Element.Name.__get__(sys_el)
+        if current_name in used:
+            used.remove(current_name)
+    except:
+        pass
+
+    prefix = _get_system_type_abbreviation(target_system_type)
+
+    i = 1
+    while i < 100000:
+        candidate = "{} {}".format(prefix, i)
+        if candidate not in used:
+            try:
+                sys_el.Name = candidate
+                return True
+            except:
+                try:
+                    DB.Element.Name.__set__(sys_el, candidate)
+                    return True
+                except Exception as ex:
+                    logger.warning("Could not set system name {}: {}".format(candidate, ex))
+                    return False
+        i += 1
+
+    logger.warning("Could not find unique system name for prefix {}".format(prefix))
+    return False
+
+
+def _pipe_is_on_system(pipe, sys_id_int):
+    try:
+        sys = pipe.MEPSystem
+        if sys and sys.Id.IntegerValue == sys_id_int:
+            return True
+    except:
+        pass
+
+    for c in iter_piping_connectors(pipe):
+        try:
+            sys = c.MEPSystem
+            if sys and sys.Id.IntegerValue == sys_id_int:
+                return True
+        except:
+            pass
+
+    return False
+
+
+def _count_selected_pipes_on_system(pipes, sys_id_int):
+    n = 0
+    for p in pipes:
+        if _pipe_is_on_system(p, sys_id_int):
+            n += 1
+    return n
+
+
+def _connectorset_has_fixture_connector(connectors):
+    for conn in connectors:
+        try:
+            if _is_plumbing_fixture_owner(conn.Owner):
+                return True
+        except:
+            pass
+    return False
+
+
+def _find_open_selected_pipe_connector(pipes):
+    for p in pipes:
+        for c in iter_piping_connectors(p):
+            try:
+                if not c.IsConnected:
+                    return c
+            except:
+                pass
+    return None
+
+
+def _get_pipe_level_id(pipe):
+    try:
+        rl = pipe.ReferenceLevel
+        if rl:
+            return rl.Id
+    except:
+        pass
+
+    try:
+        p = pipe.get_Parameter(DB.BuiltInParameter.RBS_START_LEVEL_PARAM)
+        if p:
+            lid = p.AsElementId()
+            if lid and lid.IntegerValue > 0:
+                return lid
+    except:
+        pass
+
+    try:
+        lid = pipe.LevelId
+        if lid and lid.IntegerValue > 0:
+            return lid
+    except:
+        pass
+
+    return DB.ElementId.InvalidElementId
+
+
+def _create_short_pipe_from_open_connector(open_conn, target_system_type):
+    try:
+        owner_pipe = open_conn.Owner
+    except:
+        return None
+
+    if not isinstance(owner_pipe, DBP.Pipe):
+        return None
+
+    try:
+        start = open_conn.Origin
+    except:
+        return None
+
+    direction = None
+    try:
+        direction = open_conn.CoordinateSystem.BasisZ
+    except:
+        direction = None
+
+    try:
+        if direction is None or direction.GetLength() == 0:
+            direction = DB.XYZ.BasisX
+    except:
+        direction = DB.XYZ.BasisX
+
+    try:
+        direction = direction.Normalize()
+    except:
+        direction = DB.XYZ.BasisX
+
+    stub_len = 0.1
+    end = start + direction.Multiply(stub_len)
+
+    try:
+        pipe_type_id = owner_pipe.GetTypeId()
+    except:
+        return None
+
+    level_id = _get_pipe_level_id(owner_pipe)
+    if level_id == DB.ElementId.InvalidElementId:
+        return None
+
+    try:
+        new_pipe = DBP.Pipe.Create(doc, target_system_type.Id, pipe_type_id, level_id, start, end)
+    except Exception as ex:
+        logger.warning("Stub create failed: {}".format(ex))
+        return None
+
+    try:
+        src_d = owner_pipe.get_Parameter(DB.BuiltInParameter.RBS_PIPE_DIAMETER_PARAM)
+        dst_d = new_pipe.get_Parameter(DB.BuiltInParameter.RBS_PIPE_DIAMETER_PARAM)
+        if src_d and dst_d:
+            dst_d.Set(src_d.AsDouble())
+    except:
+        pass
+
+    # Best effort connect near the start point.
+    try:
+        new_conn = find_connector_by_origin(new_pipe, start, 0.01)
+        if new_conn and (not new_conn.IsConnected):
+            new_conn.ConnectTo(open_conn)
+    except:
+        pass
+
+    return new_pipe
+
+
+def _create_system_from_open_pipe_stub(pipes, target_system_type):
+    """
+    Undefined fallback for branches with no fixture driver:
+    create a short pipe off a selected open connector and use it to drive
+    system assignment.
+    """
+    open_conn = _find_open_selected_pipe_connector(pipes)
+    if not open_conn:
+        return False, None
+
+    new_pipe = _create_short_pipe_from_open_connector(open_conn, target_system_type)
+    if not new_pipe:
+        return False, None
+
+    try:
+        p = new_pipe.get_Parameter(DB.BuiltInParameter.RBS_PIPING_SYSTEM_TYPE_PARAM)
+        if p:
+            p.Set(target_system_type.Id)
+    except:
+        pass
+
+    sys = _get_pipe_system_preop(new_pipe)
+    if not sys:
+        return False, None
+
+    sid = sys.Id.IntegerValue
+    assigned = _count_selected_pipes_on_system(pipes, sid)
+    if assigned <= 0:
+        logger.warning("Stub fallback created system {}, but no selected pipes were assigned.".format(output.linkify(sys.Id)))
+        return False, None
+
+    _set_unique_system_name(sys, target_system_type)
+    print("Stub fallback assigned selected pipes: {}".format(assigned))
+    return True, sys
+
+
+def _seed_undefined_system_with_fallback(connectors, target_system_type, pipes):
     """
     Try target type first; if connector-domain/classification blocks assignment,
-    try other seed types until at least one connector is accepted.
+    try other seed types until at least one selected pipe is actually assigned.
     """
     for seed_type in _iter_piping_system_types_for_seed(target_system_type):
         seed_name = None
@@ -513,9 +768,17 @@ def _seed_undefined_system_with_fallback(connectors, target_system_type):
                     _set_type_on_system(new_sys, target_system_type)
             except:
                 pass
-            return True, new_sys
 
-        # No connectors added for this seed type; delete empty system and try next.
+            sid = new_sys.Id.IntegerValue
+            assigned = _count_selected_pipes_on_system(pipes, sid)
+            if assigned > 0:
+                _set_unique_system_name(new_sys, target_system_type)
+                print('Selected pipes assigned to new system: {}'.format(assigned))
+                return True, new_sys
+
+            logger.warning('Seeded system {} but no selected pipes were assigned. Deleting empty/unrelated system.'.format(output.linkify(new_sys.Id)))
+
+        # No useful assignment for this seed type; delete and try next.
         try:
             doc.Delete(new_sys.Id)
         except:
@@ -546,10 +809,21 @@ def _create_system_from_eligible_connectors(pipes, target_system_type):
     if connector_count == 0:
         return False
 
-    ok, new_sys = _seed_undefined_system_with_fallback(connectors, target_system_type)
+    ok, new_sys = _seed_undefined_system_with_fallback(connectors, target_system_type, pipes)
     if ok and new_sys:
         print('Created undefined system {}'.format(output.linkify(new_sys.Id)))
-    return ok
+        return True
+
+    # Additional fallback for branches with no fixture-driven connector:
+    # create a short stub from an open selected pipe connector.
+    if not _connectorset_has_fixture_connector(connectors):
+        print('No fixture connector available; attempting open-end stub fallback.')
+        ok_stub, sys_stub = _create_system_from_open_pipe_stub(pipes, target_system_type)
+        if ok_stub and sys_stub:
+            print('Created undefined system via stub {}'.format(output.linkify(sys_stub.Id)))
+            return True
+
+    return False
 
 
 # ============================================================

--- a/AE pyTools.extension/AE pyTools.Tab/Mechanical.panel/Piping.pulldown/SetPipeSystem.pushbutton/script.py
+++ b/AE pyTools.extension/AE pyTools.Tab/Mechanical.panel/Piping.pulldown/SetPipeSystem.pushbutton/script.py
@@ -1108,20 +1108,100 @@ def _create_short_pipe_from_open_connector(pipe, open_conn, target_system_type):
     return True
 
 
-def _single_open_pipe_stub_mode(pipes, target_system_type):
-    if len(pipes) != 1:
+def _is_selected_pipe_element(el, selected_pipe_ids):
+    try:
+        return isinstance(el, DBP.Pipe) and el.Id.IntegerValue in selected_pipe_ids
+    except:
         return False
 
-    pipe = pipes[0]
-    if _get_pipe_system_preop(pipe):
+
+def _open_connector_has_selected_path_to_tee(open_conn, selected_pipe_ids):
+    try:
+        start_owner = open_conn.Owner
+        start_id = start_owner.Id.IntegerValue
+    except:
         return False
 
-    open_conn = _get_single_open_pipe_connector(pipe)
-    if not open_conn:
+    if start_id not in selected_pipe_ids:
         return False
 
-    logger.info("Single-open-pipe undefined mode detected. Creating 1/2\" inline stub.")
-    return _create_short_pipe_from_open_connector(pipe, open_conn, target_system_type)
+    queue = [start_owner]
+    visited = set()
+
+    while queue:
+        el = queue.pop(0)
+        try:
+            eid = el.Id.IntegerValue
+        except:
+            continue
+
+        if eid in visited:
+            continue
+        visited.add(eid)
+
+        for c in iter_piping_connectors(el):
+            try:
+                refs = list(c.AllRefs)
+            except:
+                refs = []
+
+            for other in refs:
+                if other == c:
+                    continue
+
+                try:
+                    other_owner = other.Owner
+                except:
+                    continue
+
+                if _owner_has_three_plus_piping_connectors(other_owner):
+                    return True
+
+                if _is_selected_pipe_element(other_owner, selected_pipe_ids):
+                    try:
+                        oid = other_owner.Id.IntegerValue
+                    except:
+                        continue
+                    if oid not in visited:
+                        queue.append(other_owner)
+
+    return False
+
+
+def _create_open_branch_stubs_from_selection(pipes, target_system_type):
+    selected_pipe_ids = set()
+    for p in pipes:
+        try:
+            selected_pipe_ids.add(p.Id.IntegerValue)
+        except:
+            pass
+
+    if not selected_pipe_ids:
+        return 0
+
+    created = 0
+    seen = set()
+
+    for pipe in pipes:
+        for conn in iter_piping_connectors(pipe):
+            try:
+                if conn.IsConnected:
+                    continue
+            except:
+                continue
+
+            key = _connector_key(conn)
+            if key in seen:
+                continue
+            seen.add(key)
+
+            if not _open_connector_has_selected_path_to_tee(conn, selected_pipe_ids):
+                continue
+
+            if _create_short_pipe_from_open_connector(pipe, conn, target_system_type):
+                created += 1
+
+    return created
 
 
 def _get_system_type_abbreviation(system_type):
@@ -1402,14 +1482,12 @@ def main():
                 logger.info("\n=== COMPLETE (PIPING PLAN A) ===\n")
                 return
 
-            stub_created = _run_tx("SetPipeSystem - Single open pipe stub",
-                                   _single_open_pipe_stub_mode,
-                                   pipes,
-                                   target_system_type)
-            if stub_created:
-                tg.Assimilate()
-                logger.info("\n=== COMPLETE (PIPING SINGLE-PIPE STUB MODE) ===\n")
-                return
+            created_stubs = _run_tx("SetPipeSystem - Create open-branch stubs",
+                                    _create_open_branch_stubs_from_selection,
+                                    pipes,
+                                    target_system_type)
+            if created_stubs > 0:
+                logger.info("Created {} open-branch stub pipe(s).".format(created_stubs))
 
             if not eval_data["undefined_network_eligible"]:
                 logger.info("\nUndefined network is not eligible for system assignment (matches Systemizer behavior).")

--- a/AE pyTools.extension/AE pyTools.Tab/Mechanical.panel/Piping.pulldown/SetPipeSystem.pushbutton/script.py
+++ b/AE pyTools.extension/AE pyTools.Tab/Mechanical.panel/Piping.pulldown/SetPipeSystem.pushbutton/script.py
@@ -532,6 +532,63 @@ def _collect_pipe_system_ids(pipes):
     return sys_ids
 
 
+def _get_pipe_system_preop(pipe):
+    """
+    Pre-operation detection for plan routing:
+    - Prefer pipe.MEPSystem
+    - Fallback to connector.MEPSystem (more reliable before topology edits)
+    """
+    sys = _get_pipe_system(pipe)
+    if sys:
+        return sys
+
+    for c in iter_piping_connectors(pipe):
+        try:
+            sys = c.MEPSystem
+        except:
+            sys = None
+        if sys:
+            return sys
+
+    return None
+
+
+def _collect_pipe_system_ids_preop(pipes):
+    """
+    System detection used for evaluation/plan selection only.
+    """
+    sys_ids = set()
+    for p in pipes:
+        sys = _get_pipe_system_preop(p)
+        if sys:
+            try:
+                sys_ids.add(sys.Id.IntegerValue)
+            except:
+                pass
+    return sys_ids
+
+
+def _collect_pipe_system_ids_from_connectors(pipes):
+    """
+    Post-disconnect/divide collector.
+    Connector-level MEPSystem is more dependable after topology edits.
+    """
+    sys_ids = set()
+    for p in pipes:
+        for c in iter_piping_connectors(p):
+            try:
+                sys = c.MEPSystem
+            except:
+                sys = None
+
+            if sys:
+                try:
+                    sys_ids.add(sys.Id.IntegerValue)
+                except:
+                    pass
+    return sys_ids
+
+
 def _set_type_on_system(sys_el, target_system_type):
     try:
         param = sys_el.LookupParameter("Type")
@@ -653,7 +710,7 @@ def _evaluate_selection(elements, pipes, saved_pairs, affected_system_ids):
     data["has_boundary_pairs"] = (len(saved_pairs) > 0)
 
     # "Has systems" means at least one selected pipe has an actual system object
-    sys_ids = _collect_pipe_system_ids(pipes)
+    sys_ids = _collect_pipe_system_ids_preop(pipes)
     data["selected_pipe_system_ids"] = sys_ids
     data["has_existing_systems"] = (len(sys_ids) > 0)
 
@@ -711,7 +768,7 @@ def main():
             eval_data["affected_system_ids"] = new_affected
 
         # Re-collect system ids from pipes post-divide (safer than relying on affected ids)
-        sys_ids_after = _collect_pipe_system_ids(pipes)
+        sys_ids_after = _collect_pipe_system_ids_from_connectors(pipes)
         _run_tx("SetPipeSystem - Set type on existing systems",
                 _set_type_on_system_ids,
                 sys_ids_after,
@@ -737,21 +794,10 @@ def main():
         print("\n=== COMPLETE (PLAN B - NOOP) ===\n")
         return
 
-    # Eligible undefined: optional disconnect/reconnect if boundary pairs exist
-    if eval_data["has_boundary_pairs"]:
-        _run_tx("SetPipeSystem - Disconnect boundary (undefined)",
-                disconnect_pairs_now,
-                saved_pairs)
-
     _run_tx("SetPipeSystem - Set type via pipe parameter (undefined)",
             _set_pipe_system_type_param,
             pipes,
             target_system_type)
-
-    if eval_data["has_boundary_pairs"]:
-        _run_tx("SetPipeSystem - Reconnect boundary (undefined)",
-                reconnect_pairs,
-                saved_pairs)
 
     print("\n=== COMPLETE (PLAN B) ===\n")
 

--- a/AE pyTools.extension/AE pyTools.Tab/Mechanical.panel/Piping.pulldown/SetPipeSystem.pushbutton/script.py
+++ b/AE pyTools.extension/AE pyTools.Tab/Mechanical.panel/Piping.pulldown/SetPipeSystem.pushbutton/script.py
@@ -593,24 +593,34 @@ def _add_eligible_connectors_to_system(new_sys, connectors):
     """
     Add connectors one-by-one so bad connectors (already used / incompatible
     classification) do not fail the entire undefined assignment attempt.
-    Returns tuple: (added_count, skipped_count)
+    Returns tuple: (added_count, skipped_count, first_skip_exception)
     """
     if not new_sys:
-        return 0, 0
+        return 0, 0, None
 
     try:
         if connectors.Size == 0:
-            logger.warning('Undefined system creation skipped: no eligible connectors found.')
-            return 0, 0
+            logger.info('Undefined system creation skipped: no eligible connectors found.')
+            return 0, 0, None
     except:
-        logger.warning('Undefined system creation skipped: invalid ConnectorSet.')
-        return 0, 0
+        logger.info('Undefined system creation skipped: invalid ConnectorSet.')
+        return 0, 0, None
 
     added = 0
     skipped = 0
     first_skip = None
 
     for conn in connectors:
+        try:
+            existing = conn.MEPSystem
+            if existing:
+                skipped += 1
+                if first_skip is None:
+                    first_skip = Exception('Connector already belongs to system {}'.format(output.linkify(existing.Id)))
+                continue
+        except:
+            pass
+
         one = DB.ConnectorSet()
         try:
             one.Insert(conn)
@@ -627,13 +637,13 @@ def _add_eligible_connectors_to_system(new_sys, connectors):
                 first_skip = ex
 
     if skipped > 0:
-        logger.warning('Skipped {} connector(s) during undefined add on {}. First error: {}'.format(
+        logger.info('Skipped {} connector(s) during undefined add on {}. First error: {}'.format(
             skipped,
             output.linkify(new_sys.Id),
             first_skip
         ))
 
-    return added, skipped
+    return added, skipped, first_skip
 
 
 def _iter_piping_system_types_for_seed(target_system_type):
@@ -678,7 +688,7 @@ def _seed_undefined_system_with_fallback(connectors, target_system_type):
         if not new_sys:
             continue
 
-        added, skipped = _add_eligible_connectors_to_system(new_sys, connectors)
+        added, skipped, first_skip = _add_eligible_connectors_to_system(new_sys, connectors)
         logger.info('Undefined seed attempt [{}] -> added: {}, skipped: {}'.format(seed_name, added, skipped))
         if added > 0:
             # If we seeded with a non-target type, flip to requested target type now.
@@ -688,6 +698,16 @@ def _seed_undefined_system_with_fallback(connectors, target_system_type):
             except:
                 pass
             return True, new_sys
+
+        try:
+            if first_skip and 'have been used' in str(first_skip):
+                try:
+                    doc.Delete(new_sys.Id)
+                except:
+                    pass
+                return False, None
+        except:
+            pass
 
         # No connectors added for this seed type; delete empty system and try next.
         try:
@@ -1034,7 +1054,7 @@ def _get_single_open_pipe_connector(pipe):
     return None
 
 
-def _create_short_pipe_from_open_connector(pipe, open_conn, target_system_type):
+def _create_short_pipe_from_open_connector(pipe, open_conn, target_system_type, created_stub_ids=None):
     length_ft = 0.5 / 12.0
 
     try:
@@ -1104,8 +1124,14 @@ def _create_short_pipe_from_open_connector(pipe, open_conn, target_system_type):
     except:
         pass
 
+    if created_stub_ids is not None:
+        try:
+            created_stub_ids.append(stub.Id.IntegerValue)
+        except:
+            pass
+
     logger.info("Created short pipe stub {} from {}".format(output.linkify(stub.Id), output.linkify(pipe.Id)))
-    return True
+    return stub
 
 
 def _is_selected_pipe_element(el, selected_pipe_ids):
@@ -1289,12 +1315,27 @@ def _create_open_branch_stubs_from_selection(pipes, target_system_type):
         except:
             pass
 
-    created = 0
+    created_stub_ids = []
     for pipe, conn in open_connectors:
-        if _create_short_pipe_from_open_connector(pipe, conn, target_system_type):
-            created += 1
+        _create_short_pipe_from_open_connector(pipe, conn, target_system_type, created_stub_ids)
 
-    return created
+    return created_stub_ids
+
+def _delete_elements_by_ids(ids_to_delete):
+    if not ids_to_delete:
+        return 0
+
+    deleted = 0
+    for sid in ids_to_delete:
+        try:
+            doc.Delete(DB.ElementId(sid))
+            deleted += 1
+        except:
+            pass
+
+    if deleted > 0:
+        logger.info('Deleted {} temporary stub pipe(s).'.format(deleted))
+    return deleted
 
 
 def _get_system_type_abbreviation(system_type):
@@ -1575,15 +1616,19 @@ def main():
                 logger.info("\n=== COMPLETE (PIPING PLAN A) ===\n")
                 return
 
-            created_stubs = _run_tx("SetPipeSystem - Create open-branch stubs",
-                                    _create_open_branch_stubs_from_selection,
-                                    pipes,
-                                    target_system_type)
-            if created_stubs > 0:
-                logger.info("Created {} open-branch stub pipe(s).".format(created_stubs))
+            created_stub_ids = _run_tx("SetPipeSystem - Create open-branch stubs",
+                                       _create_open_branch_stubs_from_selection,
+                                       pipes,
+                                       target_system_type)
+            created_stub_count = len(created_stub_ids)
+            if created_stub_count > 0:
+                logger.info("Created {} open-branch stub pipe(s).".format(created_stub_count))
 
             if not eval_data["undefined_network_eligible"]:
-                if created_stubs > 0:
+                if created_stub_count > 0:
+                    _run_tx("SetPipeSystem - Delete temporary stubs",
+                            _delete_elements_by_ids,
+                            created_stub_ids)
                     tg.Assimilate()
                     logger.info("\n=== COMPLETE (PIPING PLAN B - STUBS ONLY) ===\n")
                     return
@@ -1600,7 +1645,12 @@ def main():
                               target_system_type)
 
             if not created:
-                logger.warning("Undefined system creation did not assign any connectors.")
+                logger.info("Undefined system creation did not assign any connectors.")
+
+            if created_stub_count > 0:
+                _run_tx("SetPipeSystem - Delete temporary stubs",
+                        _delete_elements_by_ids,
+                        created_stub_ids)
 
             tg.Assimilate()
             logger.info("\n=== COMPLETE (PIPING PLAN B) ===\n")

--- a/AE pyTools.extension/AE pyTools.Tab/Mechanical.panel/Piping.pulldown/SetPipeSystem.pushbutton/script.py
+++ b/AE pyTools.extension/AE pyTools.Tab/Mechanical.panel/Piping.pulldown/SetPipeSystem.pushbutton/script.py
@@ -1115,57 +1115,117 @@ def _is_selected_pipe_element(el, selected_pipe_ids):
         return False
 
 
-def _open_connector_has_selected_path_to_tee(open_conn, selected_pipe_ids):
+def _iter_connected_piping_owners(conn):
     try:
-        start_owner = open_conn.Owner
-        start_id = start_owner.Id.IntegerValue
+        refs = list(conn.AllRefs)
     except:
-        return False
+        refs = []
 
-    if start_id not in selected_pipe_ids:
-        return False
+    for other in refs:
+        if other == conn:
+            continue
 
-    queue = [start_owner]
-    visited = set()
-
-    while queue:
-        el = queue.pop(0)
         try:
-            eid = el.Id.IntegerValue
+            owner = other.Owner
         except:
             continue
 
-        if eid in visited:
-            continue
-        visited.add(eid)
+        yield owner, other
 
-        for c in iter_piping_connectors(el):
-            try:
-                refs = list(c.AllRefs)
-            except:
-                refs = []
 
-            for other in refs:
-                if other == c:
-                    continue
+def _find_branch_open_connector_from_junction(junction_conn, selected_pipe_ids):
+    """
+    Starting from a tee/cross/wye connector, walk outward until we hit one of:
+      - open end on a pipe     -> return that open connector (if branch includes selected pipe)
+      - another junction       -> stop
+      - fixture                -> stop
+    """
+    start_owner = None
+    start_conn = None
+    for owner, other_conn in _iter_connected_piping_owners(junction_conn):
+        start_owner = owner
+        start_conn = other_conn
+        break
 
+    if not start_owner or not start_conn:
+        return None
+
+    prev_owner_id = None
+    current_owner = start_owner
+    incoming_conn = start_conn
+    visited = set()
+    branch_has_selected = False
+
+    while current_owner:
+        try:
+            owner_id = current_owner.Id.IntegerValue
+        except:
+            return None
+
+        if owner_id in visited:
+            return None
+        visited.add(owner_id)
+
+        if _is_selected_pipe_element(current_owner, selected_pipe_ids):
+            branch_has_selected = True
+
+        if _is_plumbing_fixture_owner(current_owner):
+            return None
+
+        if _owner_has_three_plus_piping_connectors(current_owner):
+            if prev_owner_id is not None:
+                return None
+
+        if isinstance(current_owner, DBP.Pipe):
+            for c in iter_piping_connectors(current_owner):
                 try:
-                    other_owner = other.Owner
+                    if not c.IsConnected:
+                        if branch_has_selected:
+                            return c
+                        return None
+                except:
+                    pass
+
+        next_owner = None
+        next_incoming = None
+
+        for c in iter_piping_connectors(current_owner):
+            if c == incoming_conn:
+                continue
+
+            for other_owner, other_conn in _iter_connected_piping_owners(c):
+                try:
+                    other_id = other_owner.Id.IntegerValue
                 except:
                     continue
 
+                if other_id == prev_owner_id:
+                    continue
+
                 if _owner_has_three_plus_piping_connectors(other_owner):
-                    return True
+                    if branch_has_selected:
+                        return None
+                    else:
+                        return None
 
-                if _is_selected_pipe_element(other_owner, selected_pipe_ids):
-                    try:
-                        oid = other_owner.Id.IntegerValue
-                    except:
-                        continue
-                    if oid not in visited:
-                        queue.append(other_owner)
+                if _is_plumbing_fixture_owner(other_owner):
+                    return None
 
-    return False
+                next_owner = other_owner
+                next_incoming = other_conn
+                break
+
+            if next_owner:
+                break
+
+        if not next_owner:
+            return None
+
+        prev_owner_id = owner_id
+        current_owner = next_owner
+        incoming_conn = next_incoming
+
+    return None
 
 
 def _create_open_branch_stubs_from_selection(pipes, target_system_type):
@@ -1179,9 +1239,10 @@ def _create_open_branch_stubs_from_selection(pipes, target_system_type):
     if not selected_pipe_ids:
         return 0
 
-    created = 0
+    open_connectors = []
     seen = set()
 
+    # 1) Any directly selected open pipe ends should always get stubs first.
     for pipe in pipes:
         for conn in iter_piping_connectors(pipe):
             try:
@@ -1191,15 +1252,47 @@ def _create_open_branch_stubs_from_selection(pipes, target_system_type):
                 continue
 
             key = _connector_key(conn)
-            if key in seen:
-                continue
-            seen.add(key)
+            if key not in seen:
+                seen.add(key)
+                open_connectors.append((pipe, conn))
 
-            if not _open_connector_has_selected_path_to_tee(conn, selected_pipe_ids):
-                continue
+    # 2) For selected pipes touching tees/crosses/wyes, walk each touched branch
+    #    out to an open end and include that open connector as well.
+    touched_junction_conns = []
+    for pipe in pipes:
+        for conn in iter_piping_connectors(pipe):
+            for other_owner, other_conn in _iter_connected_piping_owners(conn):
+                if _owner_has_three_plus_piping_connectors(other_owner):
+                    try:
+                        jkey = _connector_key(other_conn)
+                    except:
+                        jkey = None
+                    if jkey is None or jkey in seen:
+                        continue
+                    seen.add(jkey)
+                    touched_junction_conns.append(other_conn)
 
-            if _create_short_pipe_from_open_connector(pipe, conn, target_system_type):
-                created += 1
+    for junction_conn in touched_junction_conns:
+        open_conn = _find_branch_open_connector_from_junction(junction_conn, selected_pipe_ids)
+        if not open_conn:
+            continue
+
+        okey = _connector_key(open_conn)
+        if okey in seen:
+            continue
+        seen.add(okey)
+
+        try:
+            owner_pipe = open_conn.Owner
+            if isinstance(owner_pipe, DBP.Pipe):
+                open_connectors.append((owner_pipe, open_conn))
+        except:
+            pass
+
+    created = 0
+    for pipe, conn in open_connectors:
+        if _create_short_pipe_from_open_connector(pipe, conn, target_system_type):
+            created += 1
 
     return created
 
@@ -1490,6 +1583,11 @@ def main():
                 logger.info("Created {} open-branch stub pipe(s).".format(created_stubs))
 
             if not eval_data["undefined_network_eligible"]:
+                if created_stubs > 0:
+                    tg.Assimilate()
+                    logger.info("\n=== COMPLETE (PIPING PLAN B - STUBS ONLY) ===\n")
+                    return
+
                 logger.info("\nUndefined network is not eligible for system assignment (matches Systemizer behavior).")
                 logger.info("No changes made.")
                 tg.Assimilate()

--- a/AE pyTools.extension/AE pyTools.Tab/Mechanical.panel/Piping.pulldown/SetPipeSystem.pushbutton/script.py
+++ b/AE pyTools.extension/AE pyTools.Tab/Mechanical.panel/Piping.pulldown/SetPipeSystem.pushbutton/script.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 import Autodesk.Revit.DB.Plumbing as DBP
-import Autodesk.Revit.DB.Mechanical as DBM
 from System.Collections.Generic import List
 from pyrevit import revit, DB, forms, script
 
@@ -16,8 +15,8 @@ PIPING_DOMAIN = DB.Domain.DomainPiping
 
 
 # ============================================================
-# UNUSED / PARKED HELPERS (NOT USED BY CURRENT FLOW)
-# Keep these here for potential reuse in other tools.
+# SHARED HELPERS / PARKED EXPERIMENTS
+# Some helpers are active; others are intentionally retained for reuse.
 # ============================================================
 
 def xyz_equal(a, b, tol):
@@ -305,6 +304,254 @@ def network_is_eligible(pipes):
     return False
 
 
+def _is_plumbing_fixture_owner(el):
+    try:
+        cat = el.Category
+        if not cat:
+            return False
+        return cat.Id.IntegerValue == int(DB.BuiltInCategory.OST_PlumbingFixtures)
+    except:
+        return False
+
+
+def _owner_has_three_plus_piping_connectors(el):
+    count = 0
+    for _ in iter_piping_connectors(el):
+        count += 1
+        if count >= 3:
+            return True
+    return False
+
+
+def _connector_key(conn, tol_digits=6):
+    try:
+        oid = conn.Owner.Id.IntegerValue
+    except:
+        oid = -1
+
+    try:
+        o = conn.Origin
+        return (oid, round(o.X, tol_digits), round(o.Y, tol_digits), round(o.Z, tol_digits))
+    except:
+        return (oid, id(conn))
+
+
+def _collect_eligible_connectors_for_undefined_system(pipes):
+    """
+    Traverse connectivity from selected pipes and collect connectors that can
+    seed a new undefined-system assignment attempt:
+      - plumbing fixture connectors
+      - tee/cross connectors (3+ piping connectors on owner)
+
+    Tee handling note:
+    We only capture the *branch-facing* tee connector encountered from the walk,
+    not every connector on the tee owner.
+    """
+    visited = set()
+    queued = set()
+    queue = []
+
+    for p in pipes:
+        try:
+            pid = p.Id.IntegerValue
+        except:
+            continue
+        queue.append(p)
+        queued.add(pid)
+
+    con_set = DB.ConnectorSet()
+    seen_keys = set()
+    fixture_owner_added = set()
+
+    while queue:
+        el = queue.pop(0)
+        try:
+            elid = el.Id.IntegerValue
+        except:
+            continue
+
+        if elid in visited:
+            continue
+        visited.add(elid)
+
+        for c in iter_piping_connectors(el):
+            try:
+                refs = list(c.AllRefs)
+            except:
+                refs = []
+
+            for other in refs:
+                if other == c:
+                    continue
+
+                try:
+                    other_owner = other.Owner
+                    other_id = other_owner.Id.IntegerValue
+                except:
+                    continue
+
+                if other_id not in visited and other_id not in queued:
+                    queue.append(other_owner)
+                    queued.add(other_id)
+
+                # If neighboring owner is eligible, add boundary connector only.
+                # Fixture rule: add only the first connected fixture connector we hit
+                # per fixture owner to avoid grabbing unused fixture ports.
+                if _is_plumbing_fixture_owner(other_owner):
+                    if other_id in fixture_owner_added:
+                        continue
+
+                    key = _connector_key(other)
+                    if key not in seen_keys:
+                        try:
+                            con_set.Insert(other)
+                            seen_keys.add(key)
+                            fixture_owner_added.add(other_id)
+                        except:
+                            pass
+                    continue
+
+                if _owner_has_three_plus_piping_connectors(other_owner):
+                    key = _connector_key(other)
+                    if key not in seen_keys:
+                        try:
+                            con_set.Insert(other)
+                            seen_keys.add(key)
+                        except:
+                            pass
+
+    return con_set
+
+
+def _add_eligible_connectors_to_system(new_sys, connectors):
+    """
+    Add connectors one-by-one so bad connectors (already used / incompatible
+    classification) do not fail the entire undefined assignment attempt.
+    Returns tuple: (added_count, skipped_count)
+    """
+    if not new_sys:
+        return 0, 0
+
+    try:
+        if connectors.Size == 0:
+            logger.warning('Undefined system creation skipped: no eligible connectors found.')
+            return 0, 0
+    except:
+        logger.warning('Undefined system creation skipped: invalid ConnectorSet.')
+        return 0, 0
+
+    added = 0
+    skipped = 0
+
+    for conn in connectors:
+        one = DB.ConnectorSet()
+        try:
+            one.Insert(conn)
+        except:
+            skipped += 1
+            continue
+
+        try:
+            new_sys.Add(one)
+            added += 1
+        except Exception as ex:
+            skipped += 1
+            logger.warning('Skipping connector during undefined add ({}): {}'.format(output.linkify(new_sys.Id), ex))
+
+    return added, skipped
+
+
+def _iter_piping_system_types_for_seed(target_system_type):
+    """
+    Yield seed system types with target first, then all other types.
+    This allows fallback seeding when target classification is too strict for
+    the first connector assignment on undefined networks.
+    """
+    yielded = set()
+
+    if target_system_type:
+        try:
+            yielded.add(target_system_type.Id.IntegerValue)
+            yield target_system_type
+        except:
+            pass
+
+    for st in DB.FilteredElementCollector(doc).OfClass(DBP.PipingSystemType).ToElements():
+        try:
+            sid = st.Id.IntegerValue
+        except:
+            continue
+        if sid in yielded:
+            continue
+        yielded.add(sid)
+        yield st
+
+
+def _seed_undefined_system_with_fallback(connectors, target_system_type):
+    """
+    Try target type first; if connector-domain/classification blocks assignment,
+    try other seed types until at least one connector is accepted.
+    """
+    for seed_type in _iter_piping_system_types_for_seed(target_system_type):
+        seed_name = None
+        try:
+            seed_name = DB.Element.Name.__get__(seed_type)
+        except:
+            seed_name = str(seed_type.Id.IntegerValue)
+
+        new_sys = _create_empty_piping_system(seed_type)
+        if not new_sys:
+            continue
+
+        added, skipped = _add_eligible_connectors_to_system(new_sys, connectors)
+        print('Undefined seed attempt [{}] -> added: {}, skipped: {}'.format(seed_name, added, skipped))
+
+        if added > 0:
+            # If we seeded with a non-target type, flip to requested target type now.
+            try:
+                if seed_type.Id.IntegerValue != target_system_type.Id.IntegerValue:
+                    _set_type_on_system(new_sys, target_system_type)
+            except:
+                pass
+            return True, new_sys
+
+        # No connectors added for this seed type; delete empty system and try next.
+        try:
+            doc.Delete(new_sys.Id)
+        except:
+            pass
+
+    return False, None
+
+
+def _create_system_from_eligible_connectors(pipes, target_system_type):
+    """
+    Undefined mode assignment strategy requested by user:
+    1) Create a new piping system instance
+    2) Add only eligible connectors (fixtures + tee-like owners)
+    3) Use seed-type fallback to avoid connector classification dead-ends,
+       then set final type to user target.
+    """
+    print("\n--- Undefined mode: create system + add eligible connectors ---")
+
+    connectors = _collect_eligible_connectors_for_undefined_system(pipes)
+
+    try:
+        connector_count = connectors.Size
+    except:
+        connector_count = 0
+
+    print('Eligible connectors found: {}'.format(connector_count))
+
+    if connector_count == 0:
+        return False
+
+    ok, new_sys = _seed_undefined_system_with_fallback(connectors, target_system_type)
+    if ok and new_sys:
+        print('Created undefined system {}'.format(output.linkify(new_sys.Id)))
+    return ok
+
+
 # ============================================================
 # PHASE 0 — COLLECT BOUNDARY PAIRS + AFFECTED SYSTEM IDS
 # ============================================================
@@ -533,95 +780,61 @@ def _collect_pipe_system_ids(pipes):
     return sys_ids
 
 
-def _get_system_type_abbreviation(system_type):
-    try:
-        p = system_type.LookupParameter("Abbreviation")
-        if p:
-            val = p.AsString()
-            if val:
-                return val.strip()
-    except:
-        pass
+def _get_pipe_system_preop(pipe):
+    """
+    Pre-operation detection for plan routing:
+    - Prefer pipe.MEPSystem
+    - Fallback to connector.MEPSystem (more reliable before topology edits)
+    """
+    sys = _get_pipe_system(pipe)
+    if sys:
+        return sys
 
-    try:
-        p = system_type.get_Parameter(DB.BuiltInParameter.RBS_SYSTEM_ABBREVIATION_PARAM)
-        if p:
-            val = p.AsString()
-            if val:
-                return val.strip()
-    except:
-        pass
-
-    try:
-        n = DB.Element.Name.__get__(system_type)
-        if n:
-            return n.split()[0]
-    except:
-        pass
-
-    return "SYS"
-
-
-def _collect_used_mep_system_names():
-    names = set()
-
-    for s in (DB.FilteredElementCollector(doc)
-              .OfClass(DBP.PipingSystem)
-              .WhereElementIsNotElementType()
-              .ToElements()):
+    for c in iter_piping_connectors(pipe):
         try:
-            n = DB.Element.Name.__get__(s)
-            if n:
-                names.add(n)
+            sys = c.MEPSystem
         except:
-            pass
+            sys = None
+        if sys:
+            return sys
 
-    for s in (DB.FilteredElementCollector(doc)
-              .OfClass(DBM.MechanicalSystem)
-              .WhereElementIsNotElementType()
-              .ToElements()):
-        try:
-            n = DB.Element.Name.__get__(s)
-            if n:
-                names.add(n)
-        except:
-            pass
-
-    return names
+    return None
 
 
-def _set_unique_mep_system_name(system_el, target_system_type):
-    if not system_el:
-        return False
-
-    used = _collect_used_mep_system_names()
-
-    try:
-        current = DB.Element.Name.__get__(system_el)
-        if current in used:
-            used.remove(current)
-    except:
-        pass
-
-    prefix = _get_system_type_abbreviation(target_system_type)
-    i = 1
-    while i < 100000:
-        candidate = "{} {}".format(prefix, i)
-        if candidate not in used:
+def _collect_pipe_system_ids_preop(pipes):
+    """
+    System detection used for evaluation/plan selection only.
+    """
+    sys_ids = set()
+    for p in pipes:
+        sys = _get_pipe_system_preop(p)
+        if sys:
             try:
-                system_el.Name = candidate
-                return True
+                sys_ids.add(sys.Id.IntegerValue)
             except:
-                try:
-                    DB.Element.Name.__set__(system_el, candidate)
-                    return True
-                except Exception as ex:
-                    logger.warning("Could not set system name {}: {}".format(candidate, ex))
-                    return False
-        i += 1
+                pass
+    return sys_ids
 
-    logger.warning("Could not find unique system name for prefix {}".format(prefix))
-    return False
+
+def _collect_pipe_system_ids_from_connectors(pipes):
+    """
+    Post-disconnect/divide collector.
+    Connector-level MEPSystem is more dependable after topology edits.
+    """
+    sys_ids = set()
+    for p in pipes:
+        for c in iter_piping_connectors(p):
+            try:
+                sys = c.MEPSystem
+            except:
+                sys = None
+
+            if sys:
+                try:
+                    sys_ids.add(sys.Id.IntegerValue)
+                except:
+                    pass
+    return sys_ids
 
 
 def _set_type_on_system(sys_el, target_system_type):
@@ -654,7 +867,6 @@ def _set_type_on_system_ids(system_ids, target_system_type):
             continue
 
         if _set_type_on_system(sys_el, target_system_type):
-            _set_unique_mep_system_name(sys_el, target_system_type)
             ok += 1
             print("Set type on system {}".format(output.linkify(sys_el.Id)))
         else:
@@ -746,7 +958,7 @@ def _evaluate_selection(elements, pipes, saved_pairs, affected_system_ids):
     data["has_boundary_pairs"] = (len(saved_pairs) > 0)
 
     # "Has systems" means at least one selected pipe has an actual system object
-    sys_ids = _collect_pipe_system_ids(pipes)
+    sys_ids = _collect_pipe_system_ids_preop(pipes)
     data["selected_pipe_system_ids"] = sys_ids
     data["has_existing_systems"] = (len(sys_ids) > 0)
 
@@ -788,65 +1000,63 @@ def main():
     eval_data = _evaluate_selection(elements, pipes, saved_pairs, affected_system_ids)
     _print_plan(eval_data)
 
-    # --------------------------------------------------------
-    # PLAN A: Existing systems present (do NOT break this flow)
-    # Disconnect -> Divide -> Set system type on systems -> Reconnect
-    # --------------------------------------------------------
-    if eval_data["has_existing_systems"]:
-        if eval_data["has_boundary_pairs"]:
-            _run_tx("SetPipeSystem - Disconnect boundary", disconnect_pairs_now, saved_pairs)
+    with DB.TransactionGroup(doc, "SetPipeSystem - Apply Plan") as tg:
+        tg.Start()
 
-        # Divide only if we actually have affected system ids
-        if len(eval_data["affected_system_ids"]) > 0:
-            new_affected = _run_tx("SetPipeSystem - Divide affected systems",
-                                   divide_affected_systems,
-                                   eval_data["affected_system_ids"])
-            eval_data["affected_system_ids"] = new_affected
+        # --------------------------------------------------------
+        # PLAN A: Existing systems present (do NOT break this flow)
+        # Disconnect -> Divide -> Set system type on systems -> Reconnect
+        # --------------------------------------------------------
+        if eval_data["has_existing_systems"]:
+            if eval_data["has_boundary_pairs"]:
+                _run_tx("SetPipeSystem - Disconnect boundary", disconnect_pairs_now, saved_pairs)
 
-        # Re-collect system ids from pipes post-divide (safer than relying on affected ids)
-        sys_ids_after = _collect_pipe_system_ids(pipes)
-        _run_tx("SetPipeSystem - Set type on existing systems",
-                _set_type_on_system_ids,
-                sys_ids_after,
-                target_system_type)
+            # Divide only if we actually have affected system ids
+            if len(eval_data["affected_system_ids"]) > 0:
+                new_affected = _run_tx("SetPipeSystem - Divide affected systems",
+                                       divide_affected_systems,
+                                       eval_data["affected_system_ids"])
+                eval_data["affected_system_ids"] = new_affected
 
-        if eval_data["has_boundary_pairs"]:
-            _run_tx("SetPipeSystem - Reconnect boundary", reconnect_pairs, saved_pairs)
+            # Re-collect system ids from pipes post-divide (safer than relying on affected ids)
+            sys_ids_after = _collect_pipe_system_ids_from_connectors(pipes)
+            _run_tx("SetPipeSystem - Set type on existing systems",
+                    _set_type_on_system_ids,
+                    sys_ids_after,
+                    target_system_type)
 
-        print("\n=== COMPLETE (PLAN A) ===\n")
-        return
+            if eval_data["has_boundary_pairs"]:
+                _run_tx("SetPipeSystem - Reconnect boundary", reconnect_pairs, saved_pairs)
 
-    # --------------------------------------------------------
-    # PLAN B: No systems on selected pipes (undefined mode)
-    #
-    # - If eligible (tee/fixture/etc.), behave like Systemizer:
-    #   set pipe system type param and let Revit propagate.
-    #
-    # - If NOT eligible (isolated linear runs), do nothing.
-    # --------------------------------------------------------
-    if not eval_data["undefined_network_eligible"]:
-        print("\nUndefined network is not eligible for system assignment (matches Systemizer behavior).")
-        print("No changes made.")
-        print("\n=== COMPLETE (PLAN B - NOOP) ===\n")
-        return
+            tg.Assimilate()
+            print("\n=== COMPLETE (PLAN A) ===\n")
+            return
 
-    # Eligible undefined: optional disconnect/reconnect if boundary pairs exist
-    if eval_data["has_boundary_pairs"]:
-        _run_tx("SetPipeSystem - Disconnect boundary (undefined)",
-                disconnect_pairs_now,
-                saved_pairs)
+        # --------------------------------------------------------
+        # PLAN B: No systems on selected pipes (undefined mode)
+        #
+        # - If eligible (tee/fixture/etc.), create a new system and
+        #   add only eligible connectors (fixture / tee-like connectors).
+        #
+        # - If NOT eligible (isolated linear runs), do nothing.
+        # --------------------------------------------------------
+        if not eval_data["undefined_network_eligible"]:
+            print("\nUndefined network is not eligible for system assignment (matches Systemizer behavior).")
+            print("No changes made.")
+            tg.Assimilate()
+            print("\n=== COMPLETE (PLAN B - NOOP) ===\n")
+            return
 
-    _run_tx("SetPipeSystem - Set type via pipe parameter (undefined)",
-            _set_pipe_system_type_param,
-            pipes,
-            target_system_type)
+        created = _run_tx("SetPipeSystem - Create system from eligible connectors (undefined)",
+                          _create_system_from_eligible_connectors,
+                          pipes,
+                          target_system_type)
 
-    if eval_data["has_boundary_pairs"]:
-        _run_tx("SetPipeSystem - Reconnect boundary (undefined)",
-                reconnect_pairs,
-                saved_pairs)
+        if not created:
+            logger.warning("Undefined system creation did not assign any connectors.")
 
-    print("\n=== COMPLETE (PLAN B) ===\n")
+        tg.Assimilate()
+        print("\n=== COMPLETE (PLAN B) ===\n")
 
 
 if __name__ == "__main__":

--- a/AE pyTools.extension/AE pyTools.Tab/Mechanical.panel/Piping.pulldown/SetPipeSystem.pushbutton/script.py
+++ b/AE pyTools.extension/AE pyTools.Tab/Mechanical.panel/Piping.pulldown/SetPipeSystem.pushbutton/script.py
@@ -192,6 +192,31 @@ def get_selected_network_mode(elements):
         script.exit()
 
     if pipes:
+        piping_elements = []
+        for el in elements:
+            has_piping = False
+            for _ in iter_piping_connectors(el):
+                has_piping = True
+                break
+            if has_piping:
+                piping_elements.append(el)
+        return "piping", piping_elements, pipes
+
+    if ducts:
+        duct_elements = []
+        for el in elements:
+            has_duct = False
+            for _ in iter_duct_connectors(el):
+                has_duct = True
+                break
+            if has_duct:
+                duct_elements.append(el)
+        return "duct", duct_elements, ducts
+
+    logger.info("No pipes or ducts selected. Exiting.")
+    script.exit()
+
+    if pipes:
         return "piping", pipes
 
     if ducts:
@@ -542,10 +567,10 @@ def _collect_eligible_connectors_for_undefined_system(pipes):
                     if other_id in fixture_owner_added:
                         continue
 
-                    key = _connector_key(c)
+                    key = _connector_key(other)
                     if key not in seen_keys:
                         try:
-                            con_set.Insert(c)
+                            con_set.Insert(other)
                             seen_keys.add(key)
                             fixture_owner_added.add(other_id)
                         except:
@@ -1211,14 +1236,14 @@ def _print_plan(eval_data):
 def main():
     logger.info("\n=== SET MEP SYSTEM (EVALUATE -> APPLY PLAN) ===\n")
     elements = get_user_selection()
-    mode, selected_curves = get_selected_network_mode(elements)
+    mode, mode_elements, selected_curves = get_selected_network_mode(elements)
 
     if mode == "piping":
         pipes = selected_curves
         target_system_type = pick_piping_system_type()
 
-        selected_ids, saved_pairs, affected_system_ids = collect_boundary_work(pipes, iter_piping_connectors)
-        eval_data = _evaluate_selection(pipes, pipes, saved_pairs, affected_system_ids)
+        selected_ids, saved_pairs, affected_system_ids = collect_boundary_work(mode_elements, iter_piping_connectors)
+        eval_data = _evaluate_selection(mode_elements, pipes, saved_pairs, affected_system_ids)
         _print_plan(eval_data)
 
         with DB.TransactionGroup(doc, "SetPipeSystem - Apply Plan") as tg:
@@ -1272,7 +1297,7 @@ def main():
     ducts = selected_curves
     target_system_type = pick_duct_system_type()
 
-    selected_ids, saved_pairs, affected_system_ids = collect_boundary_work(ducts, iter_duct_connectors)
+    selected_ids, saved_pairs, affected_system_ids = collect_boundary_work(mode_elements, iter_duct_connectors)
     sys_ids_pre = _collect_duct_system_ids_preop(ducts)
 
     with DB.TransactionGroup(doc, "SetDuctSystem - Apply Plan") as tg:

--- a/AE pyTools.extension/AE pyTools.Tab/Mechanical.panel/Piping.pulldown/SetPipeSystem.pushbutton/script.py
+++ b/AE pyTools.extension/AE pyTools.Tab/Mechanical.panel/Piping.pulldown/SetPipeSystem.pushbutton/script.py
@@ -997,6 +997,133 @@ def _collect_pipe_system_ids_from_connectors(pipes):
     return sys_ids
 
 
+def _get_pipe_level_id(pipe):
+    try:
+        lvl = pipe.ReferenceLevel
+        if lvl:
+            return lvl.Id
+    except:
+        pass
+
+    for bip in [DB.BuiltInParameter.RBS_START_LEVEL_PARAM,
+                DB.BuiltInParameter.LEVEL_PARAM]:
+        try:
+            p = pipe.get_Parameter(bip)
+            if p:
+                lid = p.AsElementId()
+                if lid and lid != DB.ElementId.InvalidElementId:
+                    return lid
+        except:
+            pass
+
+    return None
+
+
+def _get_single_open_pipe_connector(pipe):
+    open_connectors = []
+    for c in iter_piping_connectors(pipe):
+        try:
+            if not c.IsConnected:
+                open_connectors.append(c)
+        except:
+            pass
+
+    if len(open_connectors) == 1:
+        return open_connectors[0]
+
+    return None
+
+
+def _create_short_pipe_from_open_connector(pipe, open_conn, target_system_type):
+    length_ft = 0.5 / 12.0
+
+    try:
+        start = open_conn.Origin
+    except Exception as ex:
+        logger.error("Failed to read open connector origin: {}".format(ex))
+        return False
+
+    direction = None
+    try:
+        curve = pipe.Location.Curve
+        p0 = curve.GetEndPoint(0)
+        p1 = curve.GetEndPoint(1)
+        if p0.DistanceTo(start) <= p1.DistanceTo(start):
+            direction = (p0 - p1).Normalize()
+        else:
+            direction = (p1 - p0).Normalize()
+    except:
+        pass
+
+    if not direction:
+        try:
+            direction = open_conn.CoordinateSystem.BasisZ.Normalize()
+        except Exception as ex:
+            logger.error("Failed to resolve direction for stub pipe: {}".format(ex))
+            return False
+
+    end = start + (direction.Multiply(length_ft))
+
+    pipe_type_id = pipe.GetTypeId()
+    level_id = _get_pipe_level_id(pipe)
+    if not level_id:
+        logger.error("Could not determine level for selected pipe {}".format(output.linkify(pipe.Id)))
+        return False
+
+    try:
+        stub = DBP.Pipe.Create(doc, target_system_type.Id, pipe_type_id, level_id, start, end)
+    except Exception as ex:
+        logger.error("Failed creating short pipe stub: {}".format(ex))
+        return False
+
+    try:
+        src_dia = pipe.get_Parameter(DB.BuiltInParameter.RBS_PIPE_DIAMETER_PARAM)
+        dst_dia = stub.get_Parameter(DB.BuiltInParameter.RBS_PIPE_DIAMETER_PARAM)
+        if src_dia and dst_dia:
+            dst_dia.Set(src_dia.AsDouble())
+    except Exception as ex:
+        logger.warning("Could not copy diameter to short pipe stub: {}".format(ex))
+
+    try:
+        nearest = None
+        nearest_d = None
+        for c in iter_piping_connectors(stub):
+            d = c.Origin.DistanceTo(start)
+            if nearest is None or d < nearest_d:
+                nearest = c
+                nearest_d = d
+        if nearest:
+            open_conn.ConnectTo(nearest)
+    except Exception as ex:
+        logger.warning("Could not connect short pipe stub to source connector: {}".format(ex))
+
+    try:
+        new_sys = stub.MEPSystem
+        if new_sys:
+            _set_unique_mep_system_name(new_sys, target_system_type)
+    except:
+        pass
+
+    logger.info("Created short pipe stub {} from {}".format(output.linkify(stub.Id), output.linkify(pipe.Id)))
+    return True
+
+
+def _single_open_pipe_stub_mode(pipes, target_system_type):
+    if len(pipes) != 1:
+        return False
+
+    pipe = pipes[0]
+    if _get_pipe_system_preop(pipe):
+        return False
+
+    open_conn = _get_single_open_pipe_connector(pipe)
+    if not open_conn:
+        return False
+
+    logger.info("Single-open-pipe undefined mode detected. Creating 1/2\" inline stub.")
+    return _create_short_pipe_from_open_connector(pipe, open_conn, target_system_type)
+
+
 def _get_system_type_abbreviation(system_type):
     try:
         p = system_type.LookupParameter("Abbreviation")
@@ -1273,6 +1400,15 @@ def main():
 
                 tg.Assimilate()
                 logger.info("\n=== COMPLETE (PIPING PLAN A) ===\n")
+                return
+
+            stub_created = _run_tx("SetPipeSystem - Single open pipe stub",
+                                   _single_open_pipe_stub_mode,
+                                   pipes,
+                                   target_system_type)
+            if stub_created:
+                tg.Assimilate()
+                logger.info("\n=== COMPLETE (PIPING SINGLE-PIPE STUB MODE) ===\n")
                 return
 
             if not eval_data["undefined_network_eligible"]:

--- a/AE pyTools.extension/AE pyTools.Tab/Mechanical.panel/Piping.pulldown/SetPipeSystem.pushbutton/script.py
+++ b/AE pyTools.extension/AE pyTools.Tab/Mechanical.panel/Piping.pulldown/SetPipeSystem.pushbutton/script.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import Autodesk.Revit.DB.Plumbing as DBP
+import Autodesk.Revit.DB.Mechanical as DBM
 from System.Collections.Generic import List
 from pyrevit import revit, DB, forms, script
 
@@ -15,8 +16,8 @@ PIPING_DOMAIN = DB.Domain.DomainPiping
 
 
 # ============================================================
-# SHARED HELPERS / PARKED EXPERIMENTS
-# Some helpers are active; others are intentionally retained for reuse.
+# UNUSED / PARKED HELPERS (NOT USED BY CURRENT FLOW)
+# Keep these here for potential reuse in other tools.
 # ============================================================
 
 def xyz_equal(a, b, tol):
@@ -304,497 +305,6 @@ def network_is_eligible(pipes):
     return False
 
 
-def _is_plumbing_fixture_owner(el):
-    try:
-        cat = el.Category
-        if not cat:
-            return False
-        return cat.Id.IntegerValue == int(DB.BuiltInCategory.OST_PlumbingFixtures)
-    except:
-        return False
-
-
-def _owner_has_three_plus_piping_connectors(el):
-    count = 0
-    for _ in iter_piping_connectors(el):
-        count += 1
-        if count >= 3:
-            return True
-    return False
-
-
-def _connector_key(conn, tol_digits=6):
-    try:
-        oid = conn.Owner.Id.IntegerValue
-    except:
-        oid = -1
-
-    try:
-        o = conn.Origin
-        return (oid, round(o.X, tol_digits), round(o.Y, tol_digits), round(o.Z, tol_digits))
-    except:
-        return (oid, id(conn))
-
-
-def _collect_eligible_connectors_for_undefined_system(pipes):
-    """
-    Traverse connectivity from selected pipes and collect connectors that can
-    seed a new undefined-system assignment attempt:
-      - plumbing fixture connectors
-      - tee/cross connectors (3+ piping connectors on owner)
-
-    Tee handling note:
-    We only capture the *branch-facing* tee connector encountered from the walk,
-    not every connector on the tee owner.
-    """
-    visited = set()
-    queued = set()
-    queue = []
-
-    for p in pipes:
-        try:
-            pid = p.Id.IntegerValue
-        except:
-            continue
-        queue.append(p)
-        queued.add(pid)
-
-    con_set = DB.ConnectorSet()
-    seen_keys = set()
-    fixture_owner_added = set()
-
-    while queue:
-        el = queue.pop(0)
-        try:
-            elid = el.Id.IntegerValue
-        except:
-            continue
-
-        if elid in visited:
-            continue
-        visited.add(elid)
-
-        for c in iter_piping_connectors(el):
-            try:
-                refs = list(c.AllRefs)
-            except:
-                refs = []
-
-            for other in refs:
-                if other == c:
-                    continue
-
-                try:
-                    other_owner = other.Owner
-                    other_id = other_owner.Id.IntegerValue
-                except:
-                    continue
-
-                if other_id not in visited and other_id not in queued:
-                    queue.append(other_owner)
-                    queued.add(other_id)
-
-                # If neighboring owner is eligible, add boundary connector only.
-                # Fixture rule: add only the first connected fixture connector we hit
-                # per fixture owner to avoid grabbing unused fixture ports.
-                if _is_plumbing_fixture_owner(other_owner):
-                    if other_id in fixture_owner_added:
-                        continue
-
-                    key = _connector_key(other)
-                    if key not in seen_keys:
-                        try:
-                            con_set.Insert(other)
-                            seen_keys.add(key)
-                            fixture_owner_added.add(other_id)
-                        except:
-                            pass
-                    continue
-
-                if _owner_has_three_plus_piping_connectors(other_owner):
-                    key = _connector_key(other)
-                    if key not in seen_keys:
-                        try:
-                            con_set.Insert(other)
-                            seen_keys.add(key)
-                        except:
-                            pass
-
-    return con_set
-
-
-def _add_eligible_connectors_to_system(new_sys, connectors):
-    """
-    Add connectors one-by-one so bad connectors (already used / incompatible
-    classification) do not fail the entire undefined assignment attempt.
-    Returns tuple: (added_count, skipped_count)
-    """
-    if not new_sys:
-        return 0, 0
-
-    try:
-        if connectors.Size == 0:
-            logger.warning('Undefined system creation skipped: no eligible connectors found.')
-            return 0, 0
-    except:
-        logger.warning('Undefined system creation skipped: invalid ConnectorSet.')
-        return 0, 0
-
-    added = 0
-    skipped = 0
-
-    for conn in connectors:
-        one = DB.ConnectorSet()
-        try:
-            one.Insert(conn)
-        except:
-            skipped += 1
-            continue
-
-        try:
-            new_sys.Add(one)
-            added += 1
-        except Exception as ex:
-            skipped += 1
-            logger.warning('Skipping connector during undefined add ({}): {}'.format(output.linkify(new_sys.Id), ex))
-
-    return added, skipped
-
-
-def _get_system_type_abbreviation(target_system_type):
-    """Get preferred abbreviation token for naming new systems."""
-    try:
-        p = target_system_type.LookupParameter("Abbreviation")
-        if p:
-            val = p.AsString()
-            if val:
-                return val.strip()
-    except:
-        pass
-
-    try:
-        p = target_system_type.get_Parameter(DB.BuiltInParameter.RBS_SYSTEM_ABBREVIATION_PARAM)
-        if p:
-            val = p.AsString()
-            if val:
-                return val.strip()
-    except:
-        pass
-
-    try:
-        name = DB.Element.Name.__get__(target_system_type)
-        if name:
-            return name.split()[0]
-    except:
-        pass
-
-    return "SYS"
-
-
-def _collect_used_piping_system_names():
-    names = set()
-    for s in DB.FilteredElementCollector(doc).OfClass(DBP.PipingSystem).ToElements():
-        try:
-            name = DB.Element.Name.__get__(s)
-            if name:
-                names.add(name)
-        except:
-            pass
-    return names
-
-
-def _set_unique_system_name(sys_el, target_system_type):
-    if not sys_el:
-        return False
-
-    used = _collect_used_piping_system_names()
-    try:
-        current_name = DB.Element.Name.__get__(sys_el)
-        if current_name in used:
-            used.remove(current_name)
-    except:
-        pass
-
-    prefix = _get_system_type_abbreviation(target_system_type)
-
-    i = 1
-    while i < 100000:
-        candidate = "{} {}".format(prefix, i)
-        if candidate not in used:
-            try:
-                sys_el.Name = candidate
-                return True
-            except:
-                try:
-                    DB.Element.Name.__set__(sys_el, candidate)
-                    return True
-                except Exception as ex:
-                    logger.warning("Could not set system name {}: {}".format(candidate, ex))
-                    return False
-        i += 1
-
-    logger.warning("Could not find unique system name for prefix {}".format(prefix))
-    return False
-
-
-def _pipe_is_on_system(pipe, sys_id_int):
-    try:
-        sys = pipe.MEPSystem
-        if sys and sys.Id.IntegerValue == sys_id_int:
-            return True
-    except:
-        pass
-
-    for c in iter_piping_connectors(pipe):
-        try:
-            sys = c.MEPSystem
-            if sys and sys.Id.IntegerValue == sys_id_int:
-                return True
-        except:
-            pass
-
-    return False
-
-
-def _count_selected_pipes_on_system(pipes, sys_id_int):
-    n = 0
-    for p in pipes:
-        if _pipe_is_on_system(p, sys_id_int):
-            n += 1
-    return n
-
-
-def _connectorset_has_fixture_connector(connectors):
-    for conn in connectors:
-        try:
-            if _is_plumbing_fixture_owner(conn.Owner):
-                return True
-        except:
-            pass
-    return False
-
-
-def _find_open_selected_pipe_connector(pipes):
-    for p in pipes:
-        for c in iter_piping_connectors(p):
-            try:
-                if not c.IsConnected:
-                    return c
-            except:
-                pass
-    return None
-
-
-def _get_pipe_level_id(pipe):
-    try:
-        rl = pipe.ReferenceLevel
-        if rl:
-            return rl.Id
-    except:
-        pass
-
-    try:
-        p = pipe.get_Parameter(DB.BuiltInParameter.RBS_START_LEVEL_PARAM)
-        if p:
-            lid = p.AsElementId()
-            if lid and lid.IntegerValue > 0:
-                return lid
-    except:
-        pass
-
-    try:
-        lid = pipe.LevelId
-        if lid and lid.IntegerValue > 0:
-            return lid
-    except:
-        pass
-
-    return DB.ElementId.InvalidElementId
-
-
-def _create_short_pipe_from_open_connector(open_conn, target_system_type):
-    try:
-        owner_pipe = open_conn.Owner
-    except:
-        return None
-
-    if not isinstance(owner_pipe, DBP.Pipe):
-        return None
-
-    try:
-        start = open_conn.Origin
-    except:
-        return None
-
-    direction = None
-    try:
-        direction = open_conn.CoordinateSystem.BasisZ
-    except:
-        direction = None
-
-    try:
-        if direction is None or direction.GetLength() == 0:
-            direction = DB.XYZ.BasisX
-    except:
-        direction = DB.XYZ.BasisX
-
-    try:
-        direction = direction.Normalize()
-    except:
-        direction = DB.XYZ.BasisX
-
-    stub_len = 0.1
-    end = start + direction.Multiply(stub_len)
-
-    try:
-        pipe_type_id = owner_pipe.GetTypeId()
-    except:
-        return None
-
-    level_id = _get_pipe_level_id(owner_pipe)
-    if level_id == DB.ElementId.InvalidElementId:
-        return None
-
-    try:
-        new_pipe = DBP.Pipe.Create(doc, target_system_type.Id, pipe_type_id, level_id, start, end)
-    except Exception as ex:
-        logger.warning("Stub create failed: {}".format(ex))
-        return None
-
-    try:
-        src_d = owner_pipe.get_Parameter(DB.BuiltInParameter.RBS_PIPE_DIAMETER_PARAM)
-        dst_d = new_pipe.get_Parameter(DB.BuiltInParameter.RBS_PIPE_DIAMETER_PARAM)
-        if src_d and dst_d:
-            dst_d.Set(src_d.AsDouble())
-    except:
-        pass
-
-    # Best effort connect near the start point.
-    try:
-        new_conn = find_connector_by_origin(new_pipe, start, 0.01)
-        if new_conn and (not new_conn.IsConnected):
-            new_conn.ConnectTo(open_conn)
-    except:
-        pass
-
-    return new_pipe
-
-
-def _create_system_from_open_pipe_stub(pipes, target_system_type):
-    """
-    Undefined fallback for branches with no fixture driver:
-    create a short pipe off a selected open connector and use it to drive
-    system assignment.
-    """
-    open_conn = _find_open_selected_pipe_connector(pipes)
-    if not open_conn:
-        return False, None
-
-    new_pipe = _create_short_pipe_from_open_connector(open_conn, target_system_type)
-    if not new_pipe:
-        return False, None
-
-    try:
-        p = new_pipe.get_Parameter(DB.BuiltInParameter.RBS_PIPING_SYSTEM_TYPE_PARAM)
-        if p:
-            p.Set(target_system_type.Id)
-    except:
-        pass
-
-    sys = _get_pipe_system_preop(new_pipe)
-    if not sys:
-        return False, None
-
-    sid = sys.Id.IntegerValue
-    assigned = _count_selected_pipes_on_system(pipes, sid)
-    if assigned <= 0:
-        logger.warning("Stub fallback created system {}, but no selected pipes were assigned.".format(output.linkify(sys.Id)))
-        return False, None
-
-    _set_unique_system_name(sys, target_system_type)
-    print("Stub fallback assigned selected pipes: {}".format(assigned))
-    return True, sys
-
-
-def _seed_undefined_system(connectors, target_system_type, pipes):
-    """
-    Seed undefined system using only the user-selected target system type.
-    If no selected pipes are assigned, delete the created system.
-    """
-    seed_name = None
-    try:
-        seed_name = DB.Element.Name.__get__(target_system_type)
-    except:
-        seed_name = str(target_system_type.Id.IntegerValue)
-
-    new_sys = _create_empty_piping_system(target_system_type)
-    if not new_sys:
-        return False, None
-
-    added, skipped = _add_eligible_connectors_to_system(new_sys, connectors)
-    print('Undefined seed attempt [{}] -> added: {}, skipped: {}'.format(seed_name, added, skipped))
-
-    if added <= 0:
-        try:
-            doc.Delete(new_sys.Id)
-        except:
-            pass
-        return False, None
-
-    sid = new_sys.Id.IntegerValue
-    assigned = _count_selected_pipes_on_system(pipes, sid)
-    if assigned <= 0:
-        logger.warning('Seeded system {} but no selected pipes were assigned. Deleting system.'.format(output.linkify(new_sys.Id)))
-        try:
-            doc.Delete(new_sys.Id)
-        except:
-            pass
-        return False, None
-
-    _set_unique_system_name(new_sys, target_system_type)
-    print('Selected pipes assigned to new system: {}'.format(assigned))
-    return True, new_sys
-
-
-def _create_system_from_eligible_connectors(pipes, target_system_type):
-    """
-    Undefined mode assignment strategy requested by user:
-    1) Create a new piping system instance
-    2) Add only eligible connectors (fixtures + tee-like owners)
-    3) Use seed-type fallback to avoid connector classification dead-ends,
-       then set final type to user target.
-    """
-    print("\n--- Undefined mode: create system + add eligible connectors ---")
-
-    connectors = _collect_eligible_connectors_for_undefined_system(pipes)
-
-    try:
-        connector_count = connectors.Size
-    except:
-        connector_count = 0
-
-    print('Eligible connectors found: {}'.format(connector_count))
-
-    if connector_count == 0:
-        return False
-
-    ok, new_sys = _seed_undefined_system(connectors, target_system_type, pipes)
-    if ok and new_sys:
-        print('Created undefined system {}'.format(output.linkify(new_sys.Id)))
-        return True
-
-    # Additional fallback for branches with no fixture-driven connector:
-    # create a short stub from an open selected pipe connector.
-    if not _connectorset_has_fixture_connector(connectors):
-        print('No fixture connector available; attempting open-end stub fallback.')
-        ok_stub, sys_stub = _create_system_from_open_pipe_stub(pipes, target_system_type)
-        if ok_stub and sys_stub:
-            print('Created undefined system via stub {}'.format(output.linkify(sys_stub.Id)))
-            return True
-
-    return False
-
-
 # ============================================================
 # PHASE 0 — COLLECT BOUNDARY PAIRS + AFFECTED SYSTEM IDS
 # ============================================================
@@ -1023,61 +533,95 @@ def _collect_pipe_system_ids(pipes):
     return sys_ids
 
 
-def _get_pipe_system_preop(pipe):
-    """
-    Pre-operation detection for plan routing:
-    - Prefer pipe.MEPSystem
-    - Fallback to connector.MEPSystem (more reliable before topology edits)
-    """
-    sys = _get_pipe_system(pipe)
-    if sys:
-        return sys
+def _get_system_type_abbreviation(system_type):
+    try:
+        p = system_type.LookupParameter("Abbreviation")
+        if p:
+            val = p.AsString()
+            if val:
+                return val.strip()
+    except:
+        pass
 
-    for c in iter_piping_connectors(pipe):
+    try:
+        p = system_type.get_Parameter(DB.BuiltInParameter.RBS_SYSTEM_ABBREVIATION_PARAM)
+        if p:
+            val = p.AsString()
+            if val:
+                return val.strip()
+    except:
+        pass
+
+    try:
+        n = DB.Element.Name.__get__(system_type)
+        if n:
+            return n.split()[0]
+    except:
+        pass
+
+    return "SYS"
+
+
+def _collect_used_mep_system_names():
+    names = set()
+
+    for s in (DB.FilteredElementCollector(doc)
+              .OfClass(DBP.PipingSystem)
+              .WhereElementIsNotElementType()
+              .ToElements()):
         try:
-            sys = c.MEPSystem
+            n = DB.Element.Name.__get__(s)
+            if n:
+                names.add(n)
         except:
-            sys = None
-        if sys:
-            return sys
+            pass
 
-    return None
+    for s in (DB.FilteredElementCollector(doc)
+              .OfClass(DBM.MechanicalSystem)
+              .WhereElementIsNotElementType()
+              .ToElements()):
+        try:
+            n = DB.Element.Name.__get__(s)
+            if n:
+                names.add(n)
+        except:
+            pass
+
+    return names
 
 
-def _collect_pipe_system_ids_preop(pipes):
-    """
-    System detection used for evaluation/plan selection only.
-    """
-    sys_ids = set()
-    for p in pipes:
-        sys = _get_pipe_system_preop(p)
-        if sys:
+def _set_unique_mep_system_name(system_el, target_system_type):
+    if not system_el:
+        return False
+
+    used = _collect_used_mep_system_names()
+
+    try:
+        current = DB.Element.Name.__get__(system_el)
+        if current in used:
+            used.remove(current)
+    except:
+        pass
+
+    prefix = _get_system_type_abbreviation(target_system_type)
+    i = 1
+    while i < 100000:
+        candidate = "{} {}".format(prefix, i)
+        if candidate not in used:
             try:
-                sys_ids.add(sys.Id.IntegerValue)
+                system_el.Name = candidate
+                return True
             except:
-                pass
-    return sys_ids
-
-
-def _collect_pipe_system_ids_from_connectors(pipes):
-    """
-    Post-disconnect/divide collector.
-    Connector-level MEPSystem is more dependable after topology edits.
-    """
-    sys_ids = set()
-    for p in pipes:
-        for c in iter_piping_connectors(p):
-            try:
-                sys = c.MEPSystem
-            except:
-                sys = None
-
-            if sys:
                 try:
-                    sys_ids.add(sys.Id.IntegerValue)
-                except:
-                    pass
-    return sys_ids
+                    DB.Element.Name.__set__(system_el, candidate)
+                    return True
+                except Exception as ex:
+                    logger.warning("Could not set system name {}: {}".format(candidate, ex))
+                    return False
+        i += 1
+
+    logger.warning("Could not find unique system name for prefix {}".format(prefix))
+    return False
 
 
 def _set_type_on_system(sys_el, target_system_type):
@@ -1110,6 +654,7 @@ def _set_type_on_system_ids(system_ids, target_system_type):
             continue
 
         if _set_type_on_system(sys_el, target_system_type):
+            _set_unique_mep_system_name(sys_el, target_system_type)
             ok += 1
             print("Set type on system {}".format(output.linkify(sys_el.Id)))
         else:
@@ -1201,7 +746,7 @@ def _evaluate_selection(elements, pipes, saved_pairs, affected_system_ids):
     data["has_boundary_pairs"] = (len(saved_pairs) > 0)
 
     # "Has systems" means at least one selected pipe has an actual system object
-    sys_ids = _collect_pipe_system_ids_preop(pipes)
+    sys_ids = _collect_pipe_system_ids(pipes)
     data["selected_pipe_system_ids"] = sys_ids
     data["has_existing_systems"] = (len(sys_ids) > 0)
 
@@ -1243,63 +788,65 @@ def main():
     eval_data = _evaluate_selection(elements, pipes, saved_pairs, affected_system_ids)
     _print_plan(eval_data)
 
-    with DB.TransactionGroup(doc, "SetPipeSystem - Apply Plan") as tg:
-        tg.Start()
+    # --------------------------------------------------------
+    # PLAN A: Existing systems present (do NOT break this flow)
+    # Disconnect -> Divide -> Set system type on systems -> Reconnect
+    # --------------------------------------------------------
+    if eval_data["has_existing_systems"]:
+        if eval_data["has_boundary_pairs"]:
+            _run_tx("SetPipeSystem - Disconnect boundary", disconnect_pairs_now, saved_pairs)
 
-        # --------------------------------------------------------
-        # PLAN A: Existing systems present (do NOT break this flow)
-        # Disconnect -> Divide -> Set system type on systems -> Reconnect
-        # --------------------------------------------------------
-        if eval_data["has_existing_systems"]:
-            if eval_data["has_boundary_pairs"]:
-                _run_tx("SetPipeSystem - Disconnect boundary", disconnect_pairs_now, saved_pairs)
+        # Divide only if we actually have affected system ids
+        if len(eval_data["affected_system_ids"]) > 0:
+            new_affected = _run_tx("SetPipeSystem - Divide affected systems",
+                                   divide_affected_systems,
+                                   eval_data["affected_system_ids"])
+            eval_data["affected_system_ids"] = new_affected
 
-            # Divide only if we actually have affected system ids
-            if len(eval_data["affected_system_ids"]) > 0:
-                new_affected = _run_tx("SetPipeSystem - Divide affected systems",
-                                       divide_affected_systems,
-                                       eval_data["affected_system_ids"])
-                eval_data["affected_system_ids"] = new_affected
+        # Re-collect system ids from pipes post-divide (safer than relying on affected ids)
+        sys_ids_after = _collect_pipe_system_ids(pipes)
+        _run_tx("SetPipeSystem - Set type on existing systems",
+                _set_type_on_system_ids,
+                sys_ids_after,
+                target_system_type)
 
-            # Re-collect system ids from pipes post-divide (safer than relying on affected ids)
-            sys_ids_after = _collect_pipe_system_ids_from_connectors(pipes)
-            _run_tx("SetPipeSystem - Set type on existing systems",
-                    _set_type_on_system_ids,
-                    sys_ids_after,
-                    target_system_type)
+        if eval_data["has_boundary_pairs"]:
+            _run_tx("SetPipeSystem - Reconnect boundary", reconnect_pairs, saved_pairs)
 
-            if eval_data["has_boundary_pairs"]:
-                _run_tx("SetPipeSystem - Reconnect boundary", reconnect_pairs, saved_pairs)
+        print("\n=== COMPLETE (PLAN A) ===\n")
+        return
 
-            tg.Assimilate()
-            print("\n=== COMPLETE (PLAN A) ===\n")
-            return
+    # --------------------------------------------------------
+    # PLAN B: No systems on selected pipes (undefined mode)
+    #
+    # - If eligible (tee/fixture/etc.), behave like Systemizer:
+    #   set pipe system type param and let Revit propagate.
+    #
+    # - If NOT eligible (isolated linear runs), do nothing.
+    # --------------------------------------------------------
+    if not eval_data["undefined_network_eligible"]:
+        print("\nUndefined network is not eligible for system assignment (matches Systemizer behavior).")
+        print("No changes made.")
+        print("\n=== COMPLETE (PLAN B - NOOP) ===\n")
+        return
 
-        # --------------------------------------------------------
-        # PLAN B: No systems on selected pipes (undefined mode)
-        #
-        # - If eligible (tee/fixture/etc.), create a new system and
-        #   add only eligible connectors (fixture / tee-like connectors).
-        #
-        # - If NOT eligible (isolated linear runs), do nothing.
-        # --------------------------------------------------------
-        if not eval_data["undefined_network_eligible"]:
-            print("\nUndefined network is not eligible for system assignment (matches Systemizer behavior).")
-            print("No changes made.")
-            tg.Assimilate()
-            print("\n=== COMPLETE (PLAN B - NOOP) ===\n")
-            return
+    # Eligible undefined: optional disconnect/reconnect if boundary pairs exist
+    if eval_data["has_boundary_pairs"]:
+        _run_tx("SetPipeSystem - Disconnect boundary (undefined)",
+                disconnect_pairs_now,
+                saved_pairs)
 
-        created = _run_tx("SetPipeSystem - Create system from eligible connectors (undefined)",
-                          _create_system_from_eligible_connectors,
-                          pipes,
-                          target_system_type)
+    _run_tx("SetPipeSystem - Set type via pipe parameter (undefined)",
+            _set_pipe_system_type_param,
+            pipes,
+            target_system_type)
 
-        if not created:
-            logger.warning("Undefined system creation did not assign any connectors.")
+    if eval_data["has_boundary_pairs"]:
+        _run_tx("SetPipeSystem - Reconnect boundary (undefined)",
+                reconnect_pairs,
+                saved_pairs)
 
-        tg.Assimilate()
-        print("\n=== COMPLETE (PLAN B) ===\n")
+    print("\n=== COMPLETE (PLAN B) ===\n")
 
 
 if __name__ == "__main__":

--- a/AE pyTools.extension/AE pyTools.Tab/Mechanical.panel/Piping.pulldown/SetPipeSystem.pushbutton/script.py
+++ b/AE pyTools.extension/AE pyTools.Tab/Mechanical.panel/Piping.pulldown/SetPipeSystem.pushbutton/script.py
@@ -15,8 +15,8 @@ PIPING_DOMAIN = DB.Domain.DomainPiping
 
 
 # ============================================================
-# UNUSED / PARKED HELPERS (NOT USED BY CURRENT FLOW)
-# Keep these here for potential reuse in other tools.
+# SHARED HELPERS / PARKED EXPERIMENTS
+# Some helpers are active; others are intentionally retained for reuse.
 # ============================================================
 
 def xyz_equal(a, b, tol):
@@ -302,6 +302,166 @@ def network_is_eligible(pipes):
                 pass
 
     return False
+
+
+def _is_plumbing_fixture_owner(el):
+    try:
+        cat = el.Category
+        if not cat:
+            return False
+        return cat.Id.IntegerValue == int(DB.BuiltInCategory.OST_PlumbingFixtures)
+    except:
+        return False
+
+
+def _owner_has_three_plus_piping_connectors(el):
+    count = 0
+    for _ in iter_piping_connectors(el):
+        count += 1
+        if count >= 3:
+            return True
+    return False
+
+
+def _connector_key(conn, tol_digits=6):
+    try:
+        oid = conn.Owner.Id.IntegerValue
+    except:
+        oid = -1
+
+    try:
+        o = conn.Origin
+        return (oid, round(o.X, tol_digits), round(o.Y, tol_digits), round(o.Z, tol_digits))
+    except:
+        return (oid, id(conn))
+
+
+def _collect_eligible_connectors_for_undefined_system(pipes):
+    """
+    Traverse connectivity from selected pipes and collect connectors that can
+    seed a new undefined-system assignment attempt:
+      - plumbing fixture connectors
+      - tee/cross connectors (3+ piping connectors on owner)
+    """
+    visited = set()
+    queued = set()
+    queue = []
+
+    for p in pipes:
+        try:
+            pid = p.Id.IntegerValue
+        except:
+            continue
+        queue.append(p)
+        queued.add(pid)
+
+    con_set = DB.ConnectorSet()
+    seen_keys = set()
+
+    while queue:
+        el = queue.pop(0)
+        try:
+            elid = el.Id.IntegerValue
+        except:
+            continue
+
+        if elid in visited:
+            continue
+        visited.add(elid)
+
+        is_fixture = _is_plumbing_fixture_owner(el)
+        is_tee_like = _owner_has_three_plus_piping_connectors(el)
+
+        for c in iter_piping_connectors(el):
+            if is_fixture or is_tee_like:
+                key = _connector_key(c)
+                if key not in seen_keys:
+                    try:
+                        con_set.Insert(c)
+                        seen_keys.add(key)
+                    except:
+                        pass
+
+            try:
+                refs = list(c.AllRefs)
+            except:
+                refs = []
+
+            for other in refs:
+                if other == c:
+                    continue
+
+                try:
+                    other_owner = other.Owner
+                    other_id = other_owner.Id.IntegerValue
+                except:
+                    continue
+
+                if other_id not in visited and other_id not in queued:
+                    queue.append(other_owner)
+                    queued.add(other_id)
+
+                if _is_plumbing_fixture_owner(other_owner) or _owner_has_three_plus_piping_connectors(other_owner):
+                    key = _connector_key(other)
+                    if key not in seen_keys:
+                        try:
+                            con_set.Insert(other)
+                            seen_keys.add(key)
+                        except:
+                            pass
+
+    return con_set
+
+
+def _add_eligible_connectors_to_system(new_sys, connectors):
+    if not new_sys:
+        return False
+
+    try:
+        if connectors.Size == 0:
+            logger.warning('Undefined system creation skipped: no eligible connectors found.')
+            return False
+    except:
+        logger.warning('Undefined system creation skipped: invalid ConnectorSet.')
+        return False
+
+    try:
+        new_sys.Add(connectors)
+        return True
+    except Exception as ex:
+        logger.error('Failed adding eligible connectors to system {}: {}'.format(new_sys.Id, ex))
+        return False
+
+
+def _create_system_from_eligible_connectors(pipes, target_system_type):
+    """
+    Undefined mode assignment strategy requested by user:
+    1) Create a new piping system instance
+    2) Add only eligible connectors (fixtures + tee-like owners)
+    """
+    print('\n--- Undefined mode: create system + add eligible connectors ---')
+
+    connectors = _collect_eligible_connectors_for_undefined_system(pipes)
+
+    try:
+        connector_count = connectors.Size
+    except:
+        connector_count = 0
+
+    print('Eligible connectors found: {}'.format(connector_count))
+
+    if connector_count == 0:
+        return False
+
+    new_sys = _create_empty_piping_system(target_system_type)
+    if not new_sys:
+        logger.error('Could not create new piping system for undefined network.')
+        return False
+
+    ok = _add_eligible_connectors_to_system(new_sys, connectors)
+    if ok:
+        print('Created undefined system {}'.format(output.linkify(new_sys.Id)))
+    return ok
 
 
 # ============================================================
@@ -783,8 +943,8 @@ def main():
     # --------------------------------------------------------
     # PLAN B: No systems on selected pipes (undefined mode)
     #
-    # - If eligible (tee/fixture/etc.), behave like Systemizer:
-    #   set pipe system type param and let Revit propagate.
+    # - If eligible (tee/fixture/etc.), create a new system and
+    #   add only eligible connectors (fixture / tee-like connectors).
     #
     # - If NOT eligible (isolated linear runs), do nothing.
     # --------------------------------------------------------
@@ -794,10 +954,13 @@ def main():
         print("\n=== COMPLETE (PLAN B - NOOP) ===\n")
         return
 
-    _run_tx("SetPipeSystem - Set type via pipe parameter (undefined)",
-            _set_pipe_system_type_param,
-            pipes,
-            target_system_type)
+    created = _run_tx("SetPipeSystem - Create system from eligible connectors (undefined)",
+                      _create_system_from_eligible_connectors,
+                      pipes,
+                      target_system_type)
+
+    if not created:
+        logger.warning("Undefined system creation did not assign any connectors.")
 
     print("\n=== COMPLETE (PLAN B) ===\n")
 

--- a/AE pyTools.extension/AE pyTools.Tab/Mechanical.panel/Piping.pulldown/SetPipeSystem.pushbutton/script.py
+++ b/AE pyTools.extension/AE pyTools.Tab/Mechanical.panel/Piping.pulldown/SetPipeSystem.pushbutton/script.py
@@ -342,6 +342,10 @@ def _collect_eligible_connectors_for_undefined_system(pipes):
     seed a new undefined-system assignment attempt:
       - plumbing fixture connectors
       - tee/cross connectors (3+ piping connectors on owner)
+
+    Tee handling note:
+    We only capture the *branch-facing* tee connector encountered from the walk,
+    not every connector on the tee owner.
     """
     visited = set()
     queued = set()
@@ -370,10 +374,10 @@ def _collect_eligible_connectors_for_undefined_system(pipes):
         visited.add(elid)
 
         is_fixture = _is_plumbing_fixture_owner(el)
-        is_tee_like = _owner_has_three_plus_piping_connectors(el)
 
-        for c in iter_piping_connectors(el):
-            if is_fixture or is_tee_like:
+        # Fixtures are typically endpoint owners; include their piping connectors.
+        if is_fixture:
+            for c in iter_piping_connectors(el):
                 key = _connector_key(c)
                 if key not in seen_keys:
                     try:
@@ -382,6 +386,7 @@ def _collect_eligible_connectors_for_undefined_system(pipes):
                     except:
                         pass
 
+        for c in iter_piping_connectors(el):
             try:
                 refs = list(c.AllRefs)
             except:
@@ -401,6 +406,8 @@ def _collect_eligible_connectors_for_undefined_system(pipes):
                     queue.append(other_owner)
                     queued.add(other_id)
 
+                # If the neighboring owner is a fixture or tee-like element,
+                # add only this specific boundary connector.
                 if _is_plumbing_fixture_owner(other_owner) or _owner_has_three_plus_piping_connectors(other_owner):
                     key = _connector_key(other)
                     if key not in seen_keys:
@@ -414,23 +421,104 @@ def _collect_eligible_connectors_for_undefined_system(pipes):
 
 
 def _add_eligible_connectors_to_system(new_sys, connectors):
+    """
+    Add connectors one-by-one so bad connectors (already used / incompatible
+    classification) do not fail the entire undefined assignment attempt.
+    Returns tuple: (added_count, skipped_count)
+    """
     if not new_sys:
-        return False
+        return 0, 0
 
     try:
         if connectors.Size == 0:
             logger.warning('Undefined system creation skipped: no eligible connectors found.')
-            return False
+            return 0, 0
     except:
         logger.warning('Undefined system creation skipped: invalid ConnectorSet.')
-        return False
+        return 0, 0
 
-    try:
-        new_sys.Add(connectors)
-        return True
-    except Exception as ex:
-        logger.error('Failed adding eligible connectors to system {}: {}'.format(new_sys.Id, ex))
-        return False
+    added = 0
+    skipped = 0
+
+    for conn in connectors:
+        one = DB.ConnectorSet()
+        try:
+            one.Insert(conn)
+        except:
+            skipped += 1
+            continue
+
+        try:
+            new_sys.Add(one)
+            added += 1
+        except Exception as ex:
+            skipped += 1
+            logger.warning('Skipping connector during undefined add ({}): {}'.format(output.linkify(new_sys.Id), ex))
+
+    return added, skipped
+
+
+def _iter_piping_system_types_for_seed(target_system_type):
+    """
+    Yield seed system types with target first, then all other types.
+    This allows fallback seeding when target classification is too strict for
+    the first connector assignment on undefined networks.
+    """
+    yielded = set()
+
+    if target_system_type:
+        try:
+            yielded.add(target_system_type.Id.IntegerValue)
+            yield target_system_type
+        except:
+            pass
+
+    for st in DB.FilteredElementCollector(doc).OfClass(DBP.PipingSystemType).ToElements():
+        try:
+            sid = st.Id.IntegerValue
+        except:
+            continue
+        if sid in yielded:
+            continue
+        yielded.add(sid)
+        yield st
+
+
+def _seed_undefined_system_with_fallback(connectors, target_system_type):
+    """
+    Try target type first; if connector-domain/classification blocks assignment,
+    try other seed types until at least one connector is accepted.
+    """
+    for seed_type in _iter_piping_system_types_for_seed(target_system_type):
+        seed_name = None
+        try:
+            seed_name = DB.Element.Name.__get__(seed_type)
+        except:
+            seed_name = str(seed_type.Id.IntegerValue)
+
+        new_sys = _create_empty_piping_system(seed_type)
+        if not new_sys:
+            continue
+
+        added, skipped = _add_eligible_connectors_to_system(new_sys, connectors)
+        print('Undefined seed attempt [{}] -> added: {}, skipped: {}'.format(seed_name, added, skipped))
+
+        if added > 0:
+            # If we seeded with a non-target type, flip to requested target type now.
+            try:
+                if seed_type.Id.IntegerValue != target_system_type.Id.IntegerValue:
+                    _set_type_on_system(new_sys, target_system_type)
+            except:
+                pass
+            return True, new_sys
+
+        # No connectors added for this seed type; delete empty system and try next.
+        try:
+            doc.Delete(new_sys.Id)
+        except:
+            pass
+
+    return False, None
 
 
 def _create_system_from_eligible_connectors(pipes, target_system_type):
@@ -438,8 +526,10 @@ def _create_system_from_eligible_connectors(pipes, target_system_type):
     Undefined mode assignment strategy requested by user:
     1) Create a new piping system instance
     2) Add only eligible connectors (fixtures + tee-like owners)
+    3) Use seed-type fallback to avoid connector classification dead-ends,
+       then set final type to user target.
     """
-    print('\n--- Undefined mode: create system + add eligible connectors ---')
+    print("\n--- Undefined mode: create system + add eligible connectors ---")
 
     connectors = _collect_eligible_connectors_for_undefined_system(pipes)
 
@@ -453,13 +543,8 @@ def _create_system_from_eligible_connectors(pipes, target_system_type):
     if connector_count == 0:
         return False
 
-    new_sys = _create_empty_piping_system(target_system_type)
-    if not new_sys:
-        logger.error('Could not create new piping system for undefined network.')
-        return False
-
-    ok = _add_eligible_connectors_to_system(new_sys, connectors)
-    if ok:
+    ok, new_sys = _seed_undefined_system_with_fallback(connectors, target_system_type)
+    if ok and new_sys:
         print('Created undefined system {}'.format(output.linkify(new_sys.Id)))
     return ok
 

--- a/AE pyTools.extension/AE pyTools.Tab/Mechanical.panel/Piping.pulldown/SetPipeSystem.pushbutton/script.py
+++ b/AE pyTools.extension/AE pyTools.Tab/Mechanical.panel/Piping.pulldown/SetPipeSystem.pushbutton/script.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import Autodesk.Revit.DB.Plumbing as DBP
+import Autodesk.Revit.DB.Mechanical as DBM
 from System.Collections.Generic import List
 from pyrevit import revit, DB, forms, script
 
@@ -10,6 +11,14 @@ doc = revit.doc
 logger = script.get_logger()
 output = script.get_output()
 output.close_others()
+
+VERBOSE_LOGGING = False
+
+try:
+    if hasattr(logger, "set_verbose_mode"):
+        logger.set_verbose_mode(VERBOSE_LOGGING)
+except Exception:
+    pass
 
 PIPING_DOMAIN = DB.Domain.DomainPiping
 
@@ -125,8 +134,7 @@ def _create_system_for_undefined_pipes(undefined_pipes, target_system_type):
     if not undefined_pipes:
         return False
 
-    print("\n--- Creating piping system for undefined pipes ---")
-
+    logger.info("\n--- Creating piping system for undefined pipes ---")
     new_sys = _create_empty_piping_system(target_system_type)
     if not new_sys:
         logger.error("Could not create piping system.")
@@ -134,7 +142,8 @@ def _create_system_for_undefined_pipes(undefined_pipes, target_system_type):
 
     ok = _add_pipes_to_piping_system(new_sys, undefined_pipes)
     if ok:
-        print("Created new system {}".format(output.linkify(new_sys.Id)))
+        _set_unique_mep_system_name(new_sys, target_system_type)
+        logger.info("Created new system {}".format(output.linkify(new_sys.Id)))
         return True
 
     return False
@@ -167,11 +176,10 @@ def get_user_selection():
 
 def get_selected_pipes(elements):
     pipes = [el for el in elements if isinstance(el, DBP.Pipe)]
-    print("Selected element count: {}".format(len(elements)))
-    print("Selected pipe count: {}".format(len(pipes)))
-
+    logger.info("Selected element count: {}".format(len(elements)))
+    logger.info("Selected pipe count: {}".format(len(pipes)))
     if not pipes:
-        print("No pipes selected. Exiting (Victaulic behavior).")
+        logger.info("No pipes selected. Exiting (Victaulic behavior).")
         script.exit()
 
     return pipes
@@ -235,7 +243,7 @@ def pick_disconnect_driver(conn_a, conn_b):
         a_owner = conn_a.Owner
         b_owner = conn_b.Owner
     except Exception as e:
-        print(e)
+        logger.info(e)
         return conn_a, conn_b
 
     a_is_curve = isinstance(a_owner, DB.MEPCurve)
@@ -504,8 +512,7 @@ def _seed_undefined_system_with_fallback(connectors, target_system_type):
             continue
 
         added, skipped = _add_eligible_connectors_to_system(new_sys, connectors)
-        print('Undefined seed attempt [{}] -> added: {}, skipped: {}'.format(seed_name, added, skipped))
-
+        logger.info('Undefined seed attempt [{}] -> added: {}, skipped: {}'.format(seed_name, added, skipped))
         if added > 0:
             # If we seeded with a non-target type, flip to requested target type now.
             try:
@@ -532,8 +539,7 @@ def _create_system_from_eligible_connectors(pipes, target_system_type):
     3) Use seed-type fallback to avoid connector classification dead-ends,
        then set final type to user target.
     """
-    print("\n--- Undefined mode: create system + add eligible connectors ---")
-
+    logger.info("\n--- Undefined mode: create system + add eligible connectors ---")
     connectors = _collect_eligible_connectors_for_undefined_system(pipes)
 
     try:
@@ -541,14 +547,14 @@ def _create_system_from_eligible_connectors(pipes, target_system_type):
     except:
         connector_count = 0
 
-    print('Eligible connectors found: {}'.format(connector_count))
-
+    logger.info('Eligible connectors found: {}'.format(connector_count))
     if connector_count == 0:
         return False
 
     ok, new_sys = _seed_undefined_system_with_fallback(connectors, target_system_type)
     if ok and new_sys:
-        print('Created undefined system {}'.format(output.linkify(new_sys.Id)))
+        _set_unique_mep_system_name(new_sys, target_system_type)
+        logger.info('Created undefined system {}'.format(output.linkify(new_sys.Id)))
     return ok
 
 
@@ -567,8 +573,7 @@ def collect_boundary_work(elements):
     saved_pairs = []
     affected_system_ids = set()
 
-    print("\n--- Collecting boundary connections ---")
-
+    logger.info("\n--- Collecting boundary connections ---")
     # collect systems directly from selected elements
     for el in elements:
         try:
@@ -636,8 +641,8 @@ def collect_boundary_work(elements):
                     "b_origin": target_origin
                 })
 
-    print("Boundary connection pairs found: {}".format(len(saved_pairs)))
-    print("Affected piping system ids: {}".format(len(affected_system_ids)))
+    logger.info("Boundary connection pairs found: {}".format(len(saved_pairs)))
+    logger.info("Affected piping system ids: {}".format(len(affected_system_ids)))
     return selected_ids, saved_pairs, affected_system_ids
 
 
@@ -650,7 +655,7 @@ def disconnect_pairs_now(saved_pairs):
     Disconnect using live connector objects found by origin in the current model state.
     Note: uses origin matching strategy; do not change unless you replace the pair schema.
     """
-    print("\n--- Disconnecting boundary pairs ---")
+    logger.info("\n--- Disconnecting boundary pairs ---")
     ok = 0
     fail = 0
     tol = 0.001
@@ -674,16 +679,14 @@ def disconnect_pairs_now(saved_pairs):
             if a_conn.IsConnected:
                 a_conn.DisconnectFrom(b_conn)
             ok += 1
-            print("Disconnected {} from {}".format(output.linkify(a_el.Id), output.linkify(b_el.Id)))
+            logger.info("Disconnected {} from {}".format(output.linkify(a_el.Id), output.linkify(b_el.Id)))
         except Exception as ex:
             fail += 1
             logger.warning("Failed disconnect: {}".format(ex))
 
-    print("Disconnect results -> ok: {}, fail: {}".format(ok, fail))
-
-
+    logger.info("Disconnect results -> ok: {}, fail: {}".format(ok, fail))
 def divide_affected_systems(affected_system_ids):
-    print("\n--- Dividing affected systems ---")
+    logger.info("\n--- Dividing affected systems ---")
     ok = 0
     skip = 0
     fail = 0
@@ -720,7 +723,7 @@ def divide_affected_systems(affected_system_ids):
 
             if not multi:
                 skip += 1
-                print("System {} is single network".format(output.linkify(sys_el.Id)))
+                logger.info("System {} is single network".format(output.linkify(sys_el.Id)))
                 continue
 
             try:
@@ -731,8 +734,7 @@ def divide_affected_systems(affected_system_ids):
                 continue
 
             ok += 1
-            print("Divided system {}".format(output.linkify(DB.ElementId(sid))))
-
+            logger.info("Divided system {}".format(output.linkify(DB.ElementId(sid))))
             if new_ids:
                 for nid in new_ids:
                     try:
@@ -745,10 +747,8 @@ def divide_affected_systems(affected_system_ids):
             logger.warning("Divide loop error on system {}: {}".format(sid, ex_outer))
 
     if created_ids:
-        print("New systems created by DivideSystem: {}".format(len(created_ids)))
-
-    print("Divide results -> ok: {}, skip: {}, fail: {}".format(ok, skip, fail))
-
+        logger.info("New systems created by DivideSystem: {}".format(len(created_ids)))
+    logger.info("Divide results -> ok: {}, skip: {}, fail: {}".format(ok, skip, fail))
     refreshed = set()
     for sid in survived_ids:
         refreshed.add(sid)
@@ -837,6 +837,98 @@ def _collect_pipe_system_ids_from_connectors(pipes):
     return sys_ids
 
 
+def _get_system_type_abbreviation(system_type):
+    try:
+        p = system_type.LookupParameter("Abbreviation")
+        if p:
+            val = p.AsString()
+            if val:
+                return val.strip()
+    except:
+        pass
+
+    try:
+        p = system_type.get_Parameter(DB.BuiltInParameter.RBS_SYSTEM_ABBREVIATION_PARAM)
+        if p:
+            val = p.AsString()
+            if val:
+                return val.strip()
+    except:
+        pass
+
+    try:
+        n = DB.Element.Name.__get__(system_type)
+        if n:
+            return n.split()[0]
+    except:
+        pass
+
+    return "SYS"
+
+
+def _collect_used_mep_system_names():
+    names = set()
+
+    for s in (DB.FilteredElementCollector(doc)
+              .OfClass(DBP.PipingSystem)
+              .WhereElementIsNotElementType()
+              .ToElements()):
+        try:
+            n = DB.Element.Name.__get__(s)
+            if n:
+                names.add(n)
+        except:
+            pass
+
+    for s in (DB.FilteredElementCollector(doc)
+              .OfClass(DBM.MechanicalSystem)
+              .WhereElementIsNotElementType()
+              .ToElements()):
+        try:
+            n = DB.Element.Name.__get__(s)
+            if n:
+                names.add(n)
+        except:
+            pass
+
+    return names
+
+
+def _set_unique_mep_system_name(system_el, target_system_type):
+    if not system_el:
+        return False
+
+    used = _collect_used_mep_system_names()
+
+    try:
+        current = DB.Element.Name.__get__(system_el)
+        if current in used:
+            used.remove(current)
+    except:
+        pass
+
+    prefix = _get_system_type_abbreviation(target_system_type)
+
+    i = 1
+    while i < 100000:
+        candidate = "{} {}".format(prefix, i)
+        if candidate not in used:
+            try:
+                system_el.Name = candidate
+                return True
+            except:
+                try:
+                    DB.Element.Name.__set__(system_el, candidate)
+                    return True
+                except Exception as ex:
+                    logger.warning("Could not set system name {}: {}".format(candidate, ex))
+                    return False
+        i += 1
+
+    logger.warning("Could not find unique system name for prefix {}".format(prefix))
+    return False
+
+
 def _set_type_on_system(sys_el, target_system_type):
     try:
         param = sys_el.LookupParameter("Type")
@@ -850,7 +942,7 @@ def _set_type_on_system(sys_el, target_system_type):
 
 
 def _set_type_on_system_ids(system_ids, target_system_type):
-    print("\n--- Setting system type on isolated systems (existing systems) ---")
+    logger.info("\n--- Setting system type on isolated systems (existing systems) ---")
     ok = 0
     fail = 0
     seen = set()
@@ -867,12 +959,13 @@ def _set_type_on_system_ids(system_ids, target_system_type):
             continue
 
         if _set_type_on_system(sys_el, target_system_type):
+            _set_unique_mep_system_name(sys_el, target_system_type)
             ok += 1
-            print("Set type on system {}".format(output.linkify(sys_el.Id)))
+            logger.info("Set type on system {}".format(output.linkify(sys_el.Id)))
         else:
             fail += 1
 
-    print("Set-type results -> ok: {}, fail: {}".format(ok, fail))
+    logger.info("Set-type results -> ok: {}, fail: {}".format(ok, fail))
     return ok, fail
 
 
@@ -881,7 +974,7 @@ def _set_pipe_system_type_param(pipes, target_system_type):
     For undefined networks where Revit can propagate (tee, fixture, etc.),
     this mimics Systemizer: set the pipe param and let Revit assign/propagate.
     """
-    print("\n--- Setting pipe system type param (undefined propagation mode) ---")
+    logger.info("\n--- Setting pipe system type param (undefined propagation mode) ---")
     ok = 0
     fail = 0
 
@@ -892,17 +985,17 @@ def _set_pipe_system_type_param(pipes, target_system_type):
                 raise Exception("Pipe has no RBS_PIPING_SYSTEM_TYPE_PARAM.")
             param.Set(target_system_type.Id)
             ok += 1
-            print("Set system type on pipe {}".format(output.linkify(p.Id)))
+            logger.info("Set system type on pipe {}".format(output.linkify(p.Id)))
         except Exception as ex:
             fail += 1
             logger.error("Failed setting system type on pipe {}: {}".format(p.Id, ex))
 
-    print("Pipe-param results -> ok: {}, fail: {}".format(ok, fail))
+    logger.info("Pipe-param results -> ok: {}, fail: {}".format(ok, fail))
     return ok, fail
 
 
 def reconnect_pairs(saved_pairs):
-    print("\n--- Reconnecting boundary pairs ---")
+    logger.info("\n--- Reconnecting boundary pairs ---")
     ok = 0
     fail = 0
     tol = 0.001
@@ -925,14 +1018,12 @@ def reconnect_pairs(saved_pairs):
         try:
             a_conn.ConnectTo(b_conn)
             ok += 1
-            print("Reconnected {} to {}".format(output.linkify(a_el.Id), output.linkify(b_el.Id)))
+            logger.info("Reconnected {} to {}".format(output.linkify(a_el.Id), output.linkify(b_el.Id)))
         except Exception as ex:
             fail += 1
             logger.warning("Failed reconnect: {}".format(ex))
 
-    print("Reconnect results -> ok: {}, fail: {}".format(ok, fail))
-
-
+    logger.info("Reconnect results -> ok: {}, fail: {}".format(ok, fail))
 # ============================================================
 # TRANSACTION WRAPPERS
 # ============================================================
@@ -975,21 +1066,18 @@ def _evaluate_selection(elements, pipes, saved_pairs, affected_system_ids):
 
 
 def _print_plan(eval_data):
-    print("\n--- Evaluation ---")
-    print("Has existing systems on selected pipes: {}".format(eval_data["has_existing_systems"]))
-    print("Selected pipe system id count: {}".format(len(eval_data["selected_pipe_system_ids"])))
-    print("Boundary pairs: {}".format(eval_data["boundary_pair_count"]))
-    print("Affected system ids: {}".format(len(eval_data["affected_system_ids"])))
-    print("Undefined network eligible: {}".format(eval_data["undefined_network_eligible"]))
-
-
+    logger.info("\n--- Evaluation ---")
+    logger.info("Has existing systems on selected pipes: {}".format(eval_data["has_existing_systems"]))
+    logger.info("Selected pipe system id count: {}".format(len(eval_data["selected_pipe_system_ids"])))
+    logger.info("Boundary pairs: {}".format(eval_data["boundary_pair_count"]))
+    logger.info("Affected system ids: {}".format(len(eval_data["affected_system_ids"])))
+    logger.info("Undefined network eligible: {}".format(eval_data["undefined_network_eligible"]))
 # ============================================================
 # MAIN (EVALUATE FIRST, THEN APPLY SEQUENCE)
 # ============================================================
 
 def main():
-    print("\n=== SET PIPING SYSTEM (EVALUATE -> APPLY PLAN) ===\n")
-
+    logger.info("\n=== SET PIPING SYSTEM (EVALUATE -> APPLY PLAN) ===\n")
     elements = get_user_selection()
     pipes = get_selected_pipes(elements)
     target_system_type = pick_piping_system_type()
@@ -1029,7 +1117,7 @@ def main():
                 _run_tx("SetPipeSystem - Reconnect boundary", reconnect_pairs, saved_pairs)
 
             tg.Assimilate()
-            print("\n=== COMPLETE (PLAN A) ===\n")
+            logger.info("\n=== COMPLETE (PLAN A) ===\n")
             return
 
         # --------------------------------------------------------
@@ -1041,10 +1129,10 @@ def main():
         # - If NOT eligible (isolated linear runs), do nothing.
         # --------------------------------------------------------
         if not eval_data["undefined_network_eligible"]:
-            print("\nUndefined network is not eligible for system assignment (matches Systemizer behavior).")
-            print("No changes made.")
+            logger.info("\nUndefined network is not eligible for system assignment (matches Systemizer behavior).")
+            logger.info("No changes made.")
             tg.Assimilate()
-            print("\n=== COMPLETE (PLAN B - NOOP) ===\n")
+            logger.info("\n=== COMPLETE (PLAN B - NOOP) ===\n")
             return
 
         created = _run_tx("SetPipeSystem - Create system from eligible connectors (undefined)",
@@ -1056,8 +1144,6 @@ def main():
             logger.warning("Undefined system creation did not assign any connectors.")
 
         tg.Assimilate()
-        print("\n=== COMPLETE (PLAN B) ===\n")
-
-
+        logger.info("\n=== COMPLETE (PLAN B) ===\n")
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
### Motivation

- Selected pipes were sometimes misclassified as “undefined” because `pipe.MEPSystem` can be unreliable, which caused incorrect Plan B (undefined) behavior and unwanted propagation.  
- The undefined flow previously disconnected boundaries, preventing Revit’s propagation from working like Systemizer.  
- Post-divide system targeting needed to rely on connector-level system data to correctly identify isolated systems after topology edits.

### Description

- Added pre-operation detection helpers ` _get_pipe_system_preop` and ` _collect_pipe_system_ids_preop` that fall back to connector-level `MEPSystem` for more reliable plan selection.  
- Added a connector-level post-topology collector ` _collect_pipe_system_ids_from_connectors` and switched Plan A to use it when choosing which systems to set after divide.  
- Updated evaluation to use ` _collect_pipe_system_ids_preop` so Plan A vs Plan B is decided from connector-aware pre-op data instead of only `pipe.MEPSystem`.  
- Removed the disconnect/reconnect steps from the undefined (Plan B) path so undefined-network assignment uses direct pipe parameter propagation (`RBS_PIPING_SYSTEM_TYPE_PARAM`) without topology isolation.

### Testing

- Ran `python -m py_compile "AE pyTools.extension/AE pyTools.Tab/Mechanical.panel/Piping.pulldown/SetPipeSystem.pushbutton/script.py"` and it completed successfully with no syntax errors.  
- No additional automated runtime tests were available in this environment; changes are focused on evaluation logic and were validated by static compilation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699361ff1a208326831a08088d1b1580)