### PR TITLE
Test branchrules

### DIFF
--- a/.github/workflows/bump-develop-build.yml
+++ b/.github/workflows/bump-develop-build.yml
@@ -1,0 +1,65 @@
+name: Bump Develop Build On Push
+
+on:
+  push:
+    branches:
+      - develop
+
+concurrency:
+  group: develop-build-bump
+  cancel-in-progress: true
+
+jobs:
+  bump-develop-build:
+    if: ${{ github.actor != 'github-actions[bot]' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout develop
+        uses: actions/checkout@v4
+        with:
+          ref: develop
+          fetch-depth: 0
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Bump build metadata
+        run: |
+          set -euo pipefail
+
+          ABOUT_FILE="AE pyTools.extension/AE pyTools.Tab/CED Tools.panel/About.pushbutton/about.yaml"
+          BUILD_TS="$(date -u +'%Y%m%d+%H%M')"
+
+          if [[ ! -f "${ABOUT_FILE}" ]]; then
+            echo "::error::Metadata file not found: ${ABOUT_FILE}"
+            exit 1
+          fi
+
+          python3 .github/scripts/update_release_metadata.py \
+            --file "${ABOUT_FILE}" \
+            --build "${BUILD_TS}"
+
+          read_file_key() {
+            local key="$1"
+            sed -n -E "s/^${key}:[[:space:]]*([^[:space:]]+).*/\\1/p" "${ABOUT_FILE}" | head -n1
+          }
+
+          FINAL_VERSION="$(read_file_key "toolbar_version" || true)"
+          FINAL_BUILD="$(read_file_key "build" || true)"
+
+          git add "${ABOUT_FILE}"
+
+          if git diff --cached --quiet; then
+            echo "::notice::No build metadata change detected."
+            exit 0
+          fi
+
+          COMMIT_MESSAGE="Bot: build bumped to ${FINAL_BUILD} (develop push, toolbar_version ${FINAL_VERSION})"
+          git commit -m "${COMMIT_MESSAGE}"
+          git push origin HEAD:develop
+          echo "::notice::Pushed metadata commit: ${COMMIT_MESSAGE}"

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -2,23 +2,71 @@ name: Bump Toolbar Version + Build
 
 on:
   pull_request:
-    types: [opened, synchronize, labeled, unlabeled]
+    types: [opened, reopened, synchronize, labeled, unlabeled, edited]
     branches:
       - develop
       - main
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Open PR number to bump
+        required: true
+        type: number
+
+concurrency:
+  group: bump-metadata-${{ github.event.pull_request.number || github.event.inputs.pr_number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  update-release-metadata:
-    if: ${{ github.actor != 'github-actions[bot]' }}
+  apply-release-metadata:
+    if: ${{ github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: read
 
     steps:
+      - name: Resolve PR context
+        id: prctx
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ github.event.inputs.pr_number }}
+        with:
+          script: |
+            const rawPrNumber = process.env.PR_NUMBER || "";
+            const prNumber = Number(rawPrNumber);
+            if (!Number.isInteger(prNumber) || prNumber <= 0) {
+              core.setFailed(`Invalid pr_number input: ${rawPrNumber}`);
+              return;
+            }
+
+            const { owner, repo } = context.repo;
+            const { data: pr } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: prNumber
+            });
+
+            if (pr.state !== "open") {
+              core.setFailed(`PR #${prNumber} is not open.`);
+              return;
+            }
+
+            if (pr.head.repo.full_name !== `${owner}/${repo}`) {
+              core.setFailed("PR head branch must be in this repository.");
+              return;
+            }
+
+            core.setOutput("number", String(pr.number));
+            core.setOutput("head_ref", pr.head.ref);
+            core.setOutput("base_ref", pr.base.ref);
+            core.setOutput("head_sha", pr.head.sha);
+            core.setOutput("labels_json", JSON.stringify(pr.labels.map(label => label.name)));
+
       - name: Checkout PR branch
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ steps.prctx.outputs.head_ref }}
           fetch-depth: 0
 
       - name: Configure git
@@ -26,29 +74,45 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-      - name: Update release metadata with replaceable bot commit
+      - name: Bump metadata (manual)
         env:
-          TARGET_BRANCH: ${{ github.base_ref }}
-          PR_BRANCH: ${{ github.head_ref }}
-          PR_LABELS_JSON: ${{ toJson(github.event.pull_request.labels.*.name) }}
+          TARGET_BRANCH: ${{ steps.prctx.outputs.base_ref }}
+          PR_BRANCH: ${{ steps.prctx.outputs.head_ref }}
+          PR_NUMBER: ${{ steps.prctx.outputs.number }}
+          PR_LABELS_JSON: ${{ steps.prctx.outputs.labels_json }}
         run: |
           set -euo pipefail
 
           ABOUT_FILE="AE pyTools.extension/AE pyTools.Tab/CED Tools.panel/About.pushbutton/about.yaml"
-          BOT_COMMIT_MESSAGE="Bot: update release metadata"
-          BUILD_TS="$(date -u +'%Y%m%d%H%M')"
+          BUILD_TS="$(date -u +'%Y%m%d+%H%M')"
+
+          read_file_key() {
+            local key="$1"
+            sed -n -E "s/^${key}:[[:space:]]*([^[:space:]]+).*/\\1/p" "${ABOUT_FILE}" | head -n1
+          }
+
+          read_ref_key() {
+            local git_ref="$1"
+            local key="$2"
+            git show "${git_ref}:${ABOUT_FILE}" | sed -n -E "s/^${key}:[[:space:]]*([^[:space:]]+).*/\\1/p" | head -n1
+          }
+
+          is_valid_build() {
+            [[ "$1" =~ ^[0-9]{8}\+[0-9]{4}$ ]]
+          }
 
           echo "::notice::Target branch: ${TARGET_BRANCH}"
+          echo "::notice::PR branch: ${PR_BRANCH}"
+          echo "::notice::PR number: ${PR_NUMBER}"
           echo "::notice::Detected labels: ${PR_LABELS_JSON}"
           echo "::notice::Build timestamp (UTC): ${BUILD_TS}"
 
           if [[ "${TARGET_BRANCH}" != "develop" && "${TARGET_BRANCH}" != "main" ]]; then
-            echo "::warning::Unsupported target branch '${TARGET_BRANCH}'. Skipping."
-            exit 0
+            echo "::error::Unsupported target branch '${TARGET_BRANCH}'."
+            exit 1
           fi
 
           git fetch origin "${TARGET_BRANCH}" "${PR_BRANCH}"
-          git checkout "${PR_BRANCH}"
 
           RELEASE_LABEL_COUNT=0
           RELEASE_LABEL=""
@@ -59,101 +123,255 @@ jobs:
             fi
           done
 
-          NEW_VERSION=""
+          BASE_VERSION="$(read_ref_key "origin/${TARGET_BRANCH}" "toolbar_version" || true)"
+          BASE_BUILD="$(read_ref_key "origin/${TARGET_BRANCH}" "build" || true)"
+          CURRENT_VERSION="$(read_file_key "toolbar_version" || true)"
+          CURRENT_BUILD="$(read_file_key "build" || true)"
+
+          if [[ -z "${BASE_VERSION}" || -z "${BASE_BUILD}" ]]; then
+            echo "::error::Could not read base toolbar_version/build from origin/${TARGET_BRANCH}:${ABOUT_FILE}"
+            exit 1
+          fi
+
+          if [[ -z "${CURRENT_VERSION}" || -z "${CURRENT_BUILD}" ]]; then
+            echo "::error::Could not read current toolbar_version/build from ${ABOUT_FILE}"
+            exit 1
+          fi
+
+          EXPECTED_VERSION=""
+          SHOULD_UPDATE="false"
           if [[ "${TARGET_BRANCH}" == "main" ]]; then
             if [[ "${RELEASE_LABEL_COUNT}" != "1" ]]; then
-              echo "::warning::main requires exactly one release label (major/minor/patch). Found ${RELEASE_LABEL_COUNT}. Skipping."
-              exit 0
-            fi
-
-            BASE_VERSION_RAW="$(git show "origin/main:${ABOUT_FILE}" | sed -n -E 's/^toolbar_version:[[:space:]]*([^[:space:]]+).*/\1/p' | head -n1 || true)"
-            if [[ -z "${BASE_VERSION_RAW}" ]]; then
-              echo "::warning::Could not read toolbar_version from origin/main:${ABOUT_FILE}"
+              echo "::error::main requires exactly one release label (major/minor/patch). Found ${RELEASE_LABEL_COUNT}."
               exit 1
             fi
-            BASE_VERSION="${BASE_VERSION_RAW%%-*}"
-            echo "::notice::Base version from origin/main: ${BASE_VERSION_RAW} (normalized: ${BASE_VERSION})"
 
             if [[ ! "${BASE_VERSION}" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
-              echo "::warning::Invalid base version format: ${BASE_VERSION}"
+              echo "::error::Invalid base version format in origin/${TARGET_BRANCH}: ${BASE_VERSION}"
               exit 1
             fi
 
-            MAJOR="${BASH_REMATCH[1]}"
-            MINOR="${BASH_REMATCH[2]}"
-            PATCH="${BASH_REMATCH[3]}"
+            BASE_MAJOR="${BASH_REMATCH[1]}"
+            BASE_MINOR="${BASH_REMATCH[2]}"
+            BASE_PATCH="${BASH_REMATCH[3]}"
 
             case "${RELEASE_LABEL}" in
               "release: major")
-                NEW_VERSION="$((MAJOR + 1)).0.0"
+                EXPECTED_VERSION="$((BASE_MAJOR + 1)).0.0"
                 ;;
               "release: minor")
-                NEW_VERSION="${MAJOR}.$((MINOR + 1)).0"
+                EXPECTED_VERSION="${BASE_MAJOR}.$((BASE_MINOR + 1)).0"
                 ;;
               "release: patch")
-                NEW_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))"
+                EXPECTED_VERSION="${BASE_MAJOR}.${BASE_MINOR}.$((BASE_PATCH + 1))"
                 ;;
               *)
-                echo "::warning::Unexpected release label: ${RELEASE_LABEL}"
+                echo "::error::Unexpected release label: ${RELEASE_LABEL}"
                 exit 1
                 ;;
             esac
 
-            echo "::notice::Computed new version from base: ${NEW_VERSION}"
-          else
-            echo "::notice::develop target: toolbar_version unchanged; build only."
-          fi
+            echo "::notice::Expected version for main PR: ${EXPECTED_VERSION}"
 
-          BOT_REMOVED="false"
-          EXISTING_BOT_COMMITS="$(git rev-list --reverse --author='github-actions\[bot\]' --grep='^Bot: update release metadata$' "origin/${TARGET_BRANCH}..HEAD" || true)"
-          if [[ -n "${EXISTING_BOT_COMMITS}" ]]; then
-            BOT_COUNT="$(echo "${EXISTING_BOT_COMMITS}" | sed '/^$/d' | wc -l | tr -d ' ')"
-            echo "::notice::Existing bot metadata commit(s) found: ${BOT_COUNT}. Removing before recomputing."
-            while true; do
-              BOT_SHA="$(git rev-list --reverse --author='github-actions\[bot\]' --grep='^Bot: update release metadata$' "origin/${TARGET_BRANCH}..HEAD" | head -n1 || true)"
-              if [[ -z "${BOT_SHA}" ]]; then
-                break
-              fi
-              BOT_PARENT="$(git rev-parse "${BOT_SHA}^")"
-              echo "::notice::Dropping prior bot commit: ${BOT_SHA}"
-              git rebase --rebase-merges --onto "${BOT_PARENT}" "${BOT_SHA}" HEAD
-              BOT_REMOVED="true"
-            done
-            echo "::notice::Prior bot metadata commit(s) removed."
+            if [[ "${CURRENT_VERSION}" == "${EXPECTED_VERSION}" ]] && is_valid_build "${CURRENT_BUILD}" && [[ "${CURRENT_BUILD}" != "${BASE_BUILD}" ]]; then
+              echo "::notice::Metadata already bumped for this PR. No update required."
+            else
+              SHOULD_UPDATE="true"
+            fi
           else
-            echo "::notice::No prior bot metadata commit found."
+            echo "::notice::develop target detected: build only."
+            if is_valid_build "${CURRENT_BUILD}" && [[ "${CURRENT_BUILD}" != "${BASE_BUILD}" ]]; then
+              echo "::notice::Build already bumped for this PR. No update required."
+            else
+              SHOULD_UPDATE="true"
+            fi
           fi
 
           if [[ ! -f "${ABOUT_FILE}" ]]; then
-            echo "::warning::Metadata file not found: ${ABOUT_FILE}"
+            echo "::error::Metadata file not found: ${ABOUT_FILE}"
             exit 1
           fi
 
-          if [[ -n "${NEW_VERSION}" ]]; then
-            python3 .github/scripts/update_release_metadata.py \
-              --file "${ABOUT_FILE}" \
-              --build "${BUILD_TS}" \
-              --toolbar-version "${NEW_VERSION}"
-          else
-            python3 .github/scripts/update_release_metadata.py \
-              --file "${ABOUT_FILE}" \
-              --build "${BUILD_TS}"
+          if [[ "${SHOULD_UPDATE}" == "true" ]]; then
+            if [[ "${TARGET_BRANCH}" == "main" ]]; then
+              python3 .github/scripts/update_release_metadata.py \
+                --file "${ABOUT_FILE}" \
+                --build "${BUILD_TS}" \
+                --toolbar-version "${EXPECTED_VERSION}"
+            else
+              python3 .github/scripts/update_release_metadata.py \
+                --file "${ABOUT_FILE}" \
+                --build "${BUILD_TS}"
+            fi
           fi
 
           git add "${ABOUT_FILE}"
 
           COMMIT_CREATED="false"
           if git diff --cached --quiet; then
-            echo "::notice::No metadata file change detected; commit skipped."
+            echo "::notice::No metadata file change detected."
           else
+            FINAL_VERSION="$(read_file_key "toolbar_version" || true)"
+            FINAL_BUILD="$(read_file_key "build" || true)"
+            if [[ "${TARGET_BRANCH}" == "main" ]]; then
+              BOT_COMMIT_MESSAGE="Bot: version bumped to ${FINAL_VERSION}-${FINAL_BUILD}"
+            else
+              BOT_COMMIT_MESSAGE="Bot: build bumped to ${FINAL_BUILD} (toolbar_version ${FINAL_VERSION})"
+            fi
             git commit -m "${BOT_COMMIT_MESSAGE}"
             COMMIT_CREATED="true"
             echo "::notice::Created metadata commit: ${BOT_COMMIT_MESSAGE}"
           fi
 
-          if [[ "${COMMIT_CREATED}" == "true" || "${BOT_REMOVED}" == "true" ]]; then
-            git push --force-with-lease origin "HEAD:${PR_BRANCH}"
-            echo "::notice::Pushed branch with --force-with-lease."
+          if [[ "${COMMIT_CREATED}" == "true" ]]; then
+            git push origin "HEAD:${PR_BRANCH}"
+            echo "::notice::Pushed metadata commit to ${PR_BRANCH}."
           else
             echo "::notice::No push required."
+          fi
+
+          FINAL_VERSION="$(read_file_key "toolbar_version" || true)"
+          FINAL_BUILD="$(read_file_key "build" || true)"
+
+          if [[ "${TARGET_BRANCH}" == "main" ]]; then
+            if [[ "${FINAL_VERSION}" != "${EXPECTED_VERSION}" ]]; then
+              echo "::error::Validation failed: expected toolbar_version ${EXPECTED_VERSION}, found ${FINAL_VERSION}."
+              exit 1
+            fi
+            if ! is_valid_build "${FINAL_BUILD}"; then
+              echo "::error::Validation failed: build must match YYYYMMDD+hhmm. Found ${FINAL_BUILD}."
+              exit 1
+            fi
+            if [[ "${FINAL_BUILD}" == "${BASE_BUILD}" ]]; then
+              echo "::error::Validation failed: build was not bumped from base (${BASE_BUILD})."
+              exit 1
+            fi
+            echo "::notice::Validation passed: version ${FINAL_VERSION}, build ${FINAL_BUILD}."
+          else
+            if ! is_valid_build "${FINAL_BUILD}"; then
+              echo "::error::Validation failed: build must match YYYYMMDD+hhmm. Found ${FINAL_BUILD}."
+              exit 1
+            fi
+            if [[ "${FINAL_BUILD}" == "${BASE_BUILD}" ]]; then
+              echo "::error::Validation failed: build was not bumped from base (${BASE_BUILD})."
+              exit 1
+            fi
+            echo "::notice::Validation passed: build ${FINAL_BUILD}."
+          fi
+
+  validate-release-metadata:
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
+
+      - name: Validate metadata status
+        env:
+          TARGET_BRANCH: ${{ github.base_ref }}
+          PR_BRANCH: ${{ github.head_ref }}
+          PR_LABELS_JSON: ${{ toJson(github.event.pull_request.labels.*.name) }}
+        run: |
+          set -euo pipefail
+
+          ABOUT_FILE="AE pyTools.extension/AE pyTools.Tab/CED Tools.panel/About.pushbutton/about.yaml"
+
+          read_file_key() {
+            local key="$1"
+            sed -n -E "s/^${key}:[[:space:]]*([^[:space:]]+).*/\\1/p" "${ABOUT_FILE}" | head -n1
+          }
+
+          read_ref_key() {
+            local git_ref="$1"
+            local key="$2"
+            git show "${git_ref}:${ABOUT_FILE}" | sed -n -E "s/^${key}:[[:space:]]*([^[:space:]]+).*/\\1/p" | head -n1
+          }
+
+          is_valid_build() {
+            [[ "$1" =~ ^[0-9]{8}\+[0-9]{4}$ ]]
+          }
+
+          if [[ "${TARGET_BRANCH}" != "develop" && "${TARGET_BRANCH}" != "main" ]]; then
+            echo "::notice::Unsupported target branch '${TARGET_BRANCH}'. Validation skipped."
+            exit 0
+          fi
+
+          git fetch origin "${TARGET_BRANCH}" "${PR_BRANCH}"
+
+          BASE_VERSION="$(read_ref_key "origin/${TARGET_BRANCH}" "toolbar_version" || true)"
+          BASE_BUILD="$(read_ref_key "origin/${TARGET_BRANCH}" "build" || true)"
+          CURRENT_VERSION="$(read_file_key "toolbar_version" || true)"
+          CURRENT_BUILD="$(read_file_key "build" || true)"
+
+          if [[ -z "${BASE_VERSION}" || -z "${BASE_BUILD}" ]]; then
+            echo "::error::Could not read base toolbar_version/build from origin/${TARGET_BRANCH}:${ABOUT_FILE}"
+            exit 1
+          fi
+          if [[ -z "${CURRENT_VERSION}" || -z "${CURRENT_BUILD}" ]]; then
+            echo "::error::Could not read current toolbar_version/build from ${ABOUT_FILE}"
+            exit 1
+          fi
+
+          RELEASE_LABEL_COUNT=0
+          RELEASE_LABEL=""
+          for CANDIDATE in "release: major" "release: minor" "release: patch"; do
+            if echo "${PR_LABELS_JSON}" | grep -q "\"${CANDIDATE}\""; then
+              RELEASE_LABEL_COUNT=$((RELEASE_LABEL_COUNT + 1))
+              RELEASE_LABEL="${CANDIDATE}"
+            fi
+          done
+
+          if ! is_valid_build "${CURRENT_BUILD}"; then
+            echo "::error::build must match YYYYMMDD+hhmm. Found ${CURRENT_BUILD}."
+            exit 1
+          fi
+          if [[ "${CURRENT_BUILD}" == "${BASE_BUILD}" ]]; then
+            echo "::error::build was not bumped from base branch value (${BASE_BUILD}). Run workflow_dispatch for Bump Toolbar Version + Build."
+            exit 1
+          fi
+
+          if [[ "${TARGET_BRANCH}" == "main" ]]; then
+            if [[ "${RELEASE_LABEL_COUNT}" != "1" ]]; then
+              echo "::error::main requires exactly one release label (major/minor/patch). Found ${RELEASE_LABEL_COUNT}."
+              exit 1
+            fi
+
+            if [[ ! "${BASE_VERSION}" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+              echo "::error::Invalid base version format in origin/${TARGET_BRANCH}: ${BASE_VERSION}"
+              exit 1
+            fi
+
+            BASE_MAJOR="${BASH_REMATCH[1]}"
+            BASE_MINOR="${BASH_REMATCH[2]}"
+            BASE_PATCH="${BASH_REMATCH[3]}"
+
+            case "${RELEASE_LABEL}" in
+              "release: major")
+                EXPECTED_VERSION="$((BASE_MAJOR + 1)).0.0"
+                ;;
+              "release: minor")
+                EXPECTED_VERSION="${BASE_MAJOR}.$((BASE_MINOR + 1)).0"
+                ;;
+              "release: patch")
+                EXPECTED_VERSION="${BASE_MAJOR}.${BASE_MINOR}.$((BASE_PATCH + 1))"
+                ;;
+              *)
+                echo "::error::Unexpected release label: ${RELEASE_LABEL}"
+                exit 1
+                ;;
+            esac
+
+            if [[ "${CURRENT_VERSION}" != "${EXPECTED_VERSION}" ]]; then
+              echo "::error::toolbar_version mismatch. Expected ${EXPECTED_VERSION}, found ${CURRENT_VERSION}. Run workflow_dispatch for Bump Toolbar Version + Build."
+              exit 1
+            fi
+            echo "::notice::Validation passed for main PR: version ${CURRENT_VERSION}, build ${CURRENT_BUILD}."
+          else
+            echo "::notice::Validation passed for develop PR: build ${CURRENT_BUILD}."
           fi

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, labeled, unlabeled, edited]
     branches:
-      - develop
       - main
   workflow_dispatch:
     inputs:
@@ -107,17 +106,18 @@ jobs:
           echo "::notice::Detected labels: ${PR_LABELS_JSON}"
           echo "::notice::Build timestamp (UTC): ${BUILD_TS}"
 
-          if [[ "${TARGET_BRANCH}" != "develop" && "${TARGET_BRANCH}" != "main" ]]; then
-            echo "::error::Unsupported target branch '${TARGET_BRANCH}'."
+          if [[ "${TARGET_BRANCH}" != "main" ]]; then
+            echo "::error::This workflow only supports PRs targeting main. Found target: '${TARGET_BRANCH}'."
             exit 1
           fi
 
           git fetch origin "${TARGET_BRANCH}" "${PR_BRANCH}"
 
+          PR_LABELS_JSON_LC="$(echo "${PR_LABELS_JSON}" | tr '[:upper:]' '[:lower:]')"
           RELEASE_LABEL_COUNT=0
           RELEASE_LABEL=""
-          for CANDIDATE in "release: major" "release: minor" "release: patch"; do
-            if echo "${PR_LABELS_JSON}" | grep -q "\"${CANDIDATE}\""; then
+          for CANDIDATE in "release: major" "release: minor" "release: patch" "release: none"; do
+            if echo "${PR_LABELS_JSON_LC}" | grep -q "\"${CANDIDATE}\""; then
               RELEASE_LABEL_COUNT=$((RELEASE_LABEL_COUNT + 1))
               RELEASE_LABEL="${CANDIDATE}"
             fi
@@ -140,51 +140,45 @@ jobs:
 
           EXPECTED_VERSION=""
           SHOULD_UPDATE="false"
-          if [[ "${TARGET_BRANCH}" == "main" ]]; then
-            if [[ "${RELEASE_LABEL_COUNT}" != "1" ]]; then
-              echo "::error::main requires exactly one release label (major/minor/patch). Found ${RELEASE_LABEL_COUNT}."
+          if [[ "${RELEASE_LABEL_COUNT}" != "1" ]]; then
+            echo "::error::main requires exactly one release label (release: major/minor/patch/none). Found ${RELEASE_LABEL_COUNT}."
+            exit 1
+          fi
+
+          if [[ ! "${BASE_VERSION}" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+            echo "::error::Invalid base version format in origin/${TARGET_BRANCH}: ${BASE_VERSION}"
+            exit 1
+          fi
+
+          BASE_MAJOR="${BASH_REMATCH[1]}"
+          BASE_MINOR="${BASH_REMATCH[2]}"
+          BASE_PATCH="${BASH_REMATCH[3]}"
+
+          case "${RELEASE_LABEL}" in
+            "release: major")
+              EXPECTED_VERSION="$((BASE_MAJOR + 1)).0.0"
+              ;;
+            "release: minor")
+              EXPECTED_VERSION="${BASE_MAJOR}.$((BASE_MINOR + 1)).0"
+              ;;
+            "release: patch")
+              EXPECTED_VERSION="${BASE_MAJOR}.${BASE_MINOR}.$((BASE_PATCH + 1))"
+              ;;
+            "release: none")
+              EXPECTED_VERSION="${BASE_VERSION}"
+              ;;
+            *)
+              echo "::error::Unexpected release label: ${RELEASE_LABEL}"
               exit 1
-            fi
+              ;;
+          esac
 
-            if [[ ! "${BASE_VERSION}" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
-              echo "::error::Invalid base version format in origin/${TARGET_BRANCH}: ${BASE_VERSION}"
-              exit 1
-            fi
+          echo "::notice::Expected version for main PR: ${EXPECTED_VERSION}"
 
-            BASE_MAJOR="${BASH_REMATCH[1]}"
-            BASE_MINOR="${BASH_REMATCH[2]}"
-            BASE_PATCH="${BASH_REMATCH[3]}"
-
-            case "${RELEASE_LABEL}" in
-              "release: major")
-                EXPECTED_VERSION="$((BASE_MAJOR + 1)).0.0"
-                ;;
-              "release: minor")
-                EXPECTED_VERSION="${BASE_MAJOR}.$((BASE_MINOR + 1)).0"
-                ;;
-              "release: patch")
-                EXPECTED_VERSION="${BASE_MAJOR}.${BASE_MINOR}.$((BASE_PATCH + 1))"
-                ;;
-              *)
-                echo "::error::Unexpected release label: ${RELEASE_LABEL}"
-                exit 1
-                ;;
-            esac
-
-            echo "::notice::Expected version for main PR: ${EXPECTED_VERSION}"
-
-            if [[ "${CURRENT_VERSION}" == "${EXPECTED_VERSION}" ]] && is_valid_build "${CURRENT_BUILD}" && [[ "${CURRENT_BUILD}" != "${BASE_BUILD}" ]]; then
-              echo "::notice::Metadata already bumped for this PR. No update required."
-            else
-              SHOULD_UPDATE="true"
-            fi
+          if [[ "${CURRENT_VERSION}" == "${EXPECTED_VERSION}" ]] && is_valid_build "${CURRENT_BUILD}" && [[ "${CURRENT_BUILD}" != "${BASE_BUILD}" ]]; then
+            echo "::notice::Metadata already bumped for this PR. No update required."
           else
-            echo "::notice::develop target detected: build only."
-            if is_valid_build "${CURRENT_BUILD}" && [[ "${CURRENT_BUILD}" != "${BASE_BUILD}" ]]; then
-              echo "::notice::Build already bumped for this PR. No update required."
-            else
-              SHOULD_UPDATE="true"
-            fi
+            SHOULD_UPDATE="true"
           fi
 
           if [[ ! -f "${ABOUT_FILE}" ]]; then
@@ -193,16 +187,10 @@ jobs:
           fi
 
           if [[ "${SHOULD_UPDATE}" == "true" ]]; then
-            if [[ "${TARGET_BRANCH}" == "main" ]]; then
-              python3 .github/scripts/update_release_metadata.py \
-                --file "${ABOUT_FILE}" \
-                --build "${BUILD_TS}" \
-                --toolbar-version "${EXPECTED_VERSION}"
-            else
-              python3 .github/scripts/update_release_metadata.py \
-                --file "${ABOUT_FILE}" \
-                --build "${BUILD_TS}"
-            fi
+            python3 .github/scripts/update_release_metadata.py \
+              --file "${ABOUT_FILE}" \
+              --build "${BUILD_TS}" \
+              --toolbar-version "${EXPECTED_VERSION}"
           fi
 
           git add "${ABOUT_FILE}"
@@ -213,10 +201,10 @@ jobs:
           else
             FINAL_VERSION="$(read_file_key "toolbar_version" || true)"
             FINAL_BUILD="$(read_file_key "build" || true)"
-            if [[ "${TARGET_BRANCH}" == "main" ]]; then
-              BOT_COMMIT_MESSAGE="Bot: version bumped to ${FINAL_VERSION}-${FINAL_BUILD}"
+            if [[ "${FINAL_VERSION}" == "${BASE_VERSION}" ]]; then
+              BOT_COMMIT_MESSAGE="Bot: version unchanged at ${FINAL_VERSION}; build bumped to ${FINAL_BUILD}"
             else
-              BOT_COMMIT_MESSAGE="Bot: build bumped to ${FINAL_BUILD} (toolbar_version ${FINAL_VERSION})"
+              BOT_COMMIT_MESSAGE="Bot: version bumped to ${FINAL_VERSION}-${FINAL_BUILD}"
             fi
             git commit -m "${BOT_COMMIT_MESSAGE}"
             COMMIT_CREATED="true"
@@ -233,31 +221,19 @@ jobs:
           FINAL_VERSION="$(read_file_key "toolbar_version" || true)"
           FINAL_BUILD="$(read_file_key "build" || true)"
 
-          if [[ "${TARGET_BRANCH}" == "main" ]]; then
-            if [[ "${FINAL_VERSION}" != "${EXPECTED_VERSION}" ]]; then
-              echo "::error::Validation failed: expected toolbar_version ${EXPECTED_VERSION}, found ${FINAL_VERSION}."
-              exit 1
-            fi
-            if ! is_valid_build "${FINAL_BUILD}"; then
-              echo "::error::Validation failed: build must match YYYYMMDD+hhmm. Found ${FINAL_BUILD}."
-              exit 1
-            fi
-            if [[ "${FINAL_BUILD}" == "${BASE_BUILD}" ]]; then
-              echo "::error::Validation failed: build was not bumped from base (${BASE_BUILD})."
-              exit 1
-            fi
-            echo "::notice::Validation passed: version ${FINAL_VERSION}, build ${FINAL_BUILD}."
-          else
-            if ! is_valid_build "${FINAL_BUILD}"; then
-              echo "::error::Validation failed: build must match YYYYMMDD+hhmm. Found ${FINAL_BUILD}."
-              exit 1
-            fi
-            if [[ "${FINAL_BUILD}" == "${BASE_BUILD}" ]]; then
-              echo "::error::Validation failed: build was not bumped from base (${BASE_BUILD})."
-              exit 1
-            fi
-            echo "::notice::Validation passed: build ${FINAL_BUILD}."
+          if [[ "${FINAL_VERSION}" != "${EXPECTED_VERSION}" ]]; then
+            echo "::error::Validation failed: expected toolbar_version ${EXPECTED_VERSION}, found ${FINAL_VERSION}."
+            exit 1
           fi
+          if ! is_valid_build "${FINAL_BUILD}"; then
+            echo "::error::Validation failed: build must match YYYYMMDD+hhmm. Found ${FINAL_BUILD}."
+            exit 1
+          fi
+          if [[ "${FINAL_BUILD}" == "${BASE_BUILD}" ]]; then
+            echo "::error::Validation failed: build was not bumped from base (${BASE_BUILD})."
+            exit 1
+          fi
+          echo "::notice::Validation passed: version ${FINAL_VERSION}, build ${FINAL_BUILD}."
 
   validate-release-metadata:
     if: ${{ github.event_name == 'pull_request' }}
@@ -297,7 +273,7 @@ jobs:
             [[ "$1" =~ ^[0-9]{8}\+[0-9]{4}$ ]]
           }
 
-          if [[ "${TARGET_BRANCH}" != "develop" && "${TARGET_BRANCH}" != "main" ]]; then
+          if [[ "${TARGET_BRANCH}" != "main" ]]; then
             echo "::notice::Unsupported target branch '${TARGET_BRANCH}'. Validation skipped."
             exit 0
           fi
@@ -318,10 +294,11 @@ jobs:
             exit 1
           fi
 
+          PR_LABELS_JSON_LC="$(echo "${PR_LABELS_JSON}" | tr '[:upper:]' '[:lower:]')"
           RELEASE_LABEL_COUNT=0
           RELEASE_LABEL=""
-          for CANDIDATE in "release: major" "release: minor" "release: patch"; do
-            if echo "${PR_LABELS_JSON}" | grep -q "\"${CANDIDATE}\""; then
+          for CANDIDATE in "release: major" "release: minor" "release: patch" "release: none"; do
+            if echo "${PR_LABELS_JSON_LC}" | grep -q "\"${CANDIDATE}\""; then
               RELEASE_LABEL_COUNT=$((RELEASE_LABEL_COUNT + 1))
               RELEASE_LABEL="${CANDIDATE}"
             fi
@@ -336,42 +313,41 @@ jobs:
             exit 1
           fi
 
-          if [[ "${TARGET_BRANCH}" == "main" ]]; then
-            if [[ "${RELEASE_LABEL_COUNT}" != "1" ]]; then
-              echo "::error::main requires exactly one release label (major/minor/patch). Found ${RELEASE_LABEL_COUNT}."
-              exit 1
-            fi
-
-            if [[ ! "${BASE_VERSION}" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
-              echo "::error::Invalid base version format in origin/${TARGET_BRANCH}: ${BASE_VERSION}"
-              exit 1
-            fi
-
-            BASE_MAJOR="${BASH_REMATCH[1]}"
-            BASE_MINOR="${BASH_REMATCH[2]}"
-            BASE_PATCH="${BASH_REMATCH[3]}"
-
-            case "${RELEASE_LABEL}" in
-              "release: major")
-                EXPECTED_VERSION="$((BASE_MAJOR + 1)).0.0"
-                ;;
-              "release: minor")
-                EXPECTED_VERSION="${BASE_MAJOR}.$((BASE_MINOR + 1)).0"
-                ;;
-              "release: patch")
-                EXPECTED_VERSION="${BASE_MAJOR}.${BASE_MINOR}.$((BASE_PATCH + 1))"
-                ;;
-              *)
-                echo "::error::Unexpected release label: ${RELEASE_LABEL}"
-                exit 1
-                ;;
-            esac
-
-            if [[ "${CURRENT_VERSION}" != "${EXPECTED_VERSION}" ]]; then
-              echo "::error::toolbar_version mismatch. Expected ${EXPECTED_VERSION}, found ${CURRENT_VERSION}. Run workflow_dispatch for Bump Toolbar Version + Build."
-              exit 1
-            fi
-            echo "::notice::Validation passed for main PR: version ${CURRENT_VERSION}, build ${CURRENT_BUILD}."
-          else
-            echo "::notice::Validation passed for develop PR: build ${CURRENT_BUILD}."
+          if [[ "${RELEASE_LABEL_COUNT}" != "1" ]]; then
+            echo "::error::main requires exactly one release label (release: major/minor/patch/none). Found ${RELEASE_LABEL_COUNT}."
+            exit 1
           fi
+
+          if [[ ! "${BASE_VERSION}" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+            echo "::error::Invalid base version format in origin/${TARGET_BRANCH}: ${BASE_VERSION}"
+            exit 1
+          fi
+
+          BASE_MAJOR="${BASH_REMATCH[1]}"
+          BASE_MINOR="${BASH_REMATCH[2]}"
+          BASE_PATCH="${BASH_REMATCH[3]}"
+
+          case "${RELEASE_LABEL}" in
+            "release: major")
+              EXPECTED_VERSION="$((BASE_MAJOR + 1)).0.0"
+              ;;
+            "release: minor")
+              EXPECTED_VERSION="${BASE_MAJOR}.$((BASE_MINOR + 1)).0"
+              ;;
+            "release: patch")
+              EXPECTED_VERSION="${BASE_MAJOR}.${BASE_MINOR}.$((BASE_PATCH + 1))"
+              ;;
+            "release: none")
+              EXPECTED_VERSION="${BASE_VERSION}"
+              ;;
+            *)
+              echo "::error::Unexpected release label: ${RELEASE_LABEL}"
+              exit 1
+              ;;
+          esac
+
+          if [[ "${CURRENT_VERSION}" != "${EXPECTED_VERSION}" ]]; then
+            echo "::error::toolbar_version mismatch. Expected ${EXPECTED_VERSION}, found ${CURRENT_VERSION}. Run workflow_dispatch for Bump Toolbar Version + Build."
+            exit 1
+          fi
+          echo "::notice::Validation passed for main PR: version ${CURRENT_VERSION}, build ${CURRENT_BUILD}."

--- a/.github/workflows/enforce-release-label.yml
+++ b/.github/workflows/enforce-release-label.yml
@@ -14,19 +14,21 @@ jobs:
       - name: Validate release label
         run: |
           LABELS='${{ toJson(github.event.pull_request.labels.*.name) }}'
+          LABELS_LC="$(echo "$LABELS" | tr '[:upper:]' '[:lower:]')"
 
           echo "Labels JSON: $LABELS"
 
           COUNT=0
 
-          if echo "$LABELS" | grep -q '"release: major"'; then COUNT=$((COUNT+1)); fi
-          if echo "$LABELS" | grep -q '"release: minor"'; then COUNT=$((COUNT+1)); fi
-          if echo "$LABELS" | grep -q '"release: patch"'; then COUNT=$((COUNT+1)); fi
+          if echo "$LABELS_LC" | grep -q '"release: major"'; then COUNT=$((COUNT+1)); fi
+          if echo "$LABELS_LC" | grep -q '"release: minor"'; then COUNT=$((COUNT+1)); fi
+          if echo "$LABELS_LC" | grep -q '"release: patch"'; then COUNT=$((COUNT+1)); fi
+          if echo "$LABELS_LC" | grep -q '"release: none"'; then COUNT=$((COUNT+1)); fi
 
           echo "Release label count: $COUNT"
 
           if [ "$COUNT" -eq 0 ]; then
-            echo "::error::PR must have one of: release: major, minor, patch"
+            echo "::error::PR must have one of: release: major, release: minor, release: patch, release: none"
             exit 1
           fi
 

--- a/AE pyTools.extension/AE pyTools.Tab/CED Tools.panel/About.pushbutton/AboutWindow.xaml
+++ b/AE pyTools.extension/AE pyTools.Tab/CED Tools.panel/About.pushbutton/AboutWindow.xaml
@@ -125,9 +125,9 @@
                         <RowDefinition Height="Auto" />
                     </Grid.RowDefinitions>
 
-                    <!-- Toolbar Version -->
+                    <!-- Toolbar Version + Build -->
                     <TextBlock Grid.Row="0" Grid.Column="0"
-               Text="Toolbar Version:"
+               Text="Toolbar Version/Build:"
                FontWeight="SemiBold"
                VerticalAlignment="Center"/>
                     <TextBlock Grid.Row="0" Grid.Column="2"

--- a/AE pyTools.extension/AE pyTools.Tab/CED Tools.panel/About.pushbutton/about.yaml
+++ b/AE pyTools.extension/AE pyTools.Tab/CED Tools.panel/About.pushbutton/about.yaml
@@ -1,5 +1,5 @@
 toolbar_version: 2.0.4
-build: 202604232059
+build: 20260423+2059
 authors:
 - Matt Gonzales
 - Anthony Evelina

--- a/AE pyTools.extension/AE pyTools.Tab/CED Tools.panel/About.pushbutton/script.py
+++ b/AE pyTools.extension/AE pyTools.Tab/CED Tools.panel/About.pushbutton/script.py
@@ -2,6 +2,7 @@
 """CED About window."""
 
 import os
+import re
 
 from pyrevit import forms, script, versionmgr
 
@@ -16,6 +17,7 @@ TRAINING_URL = "https://productivitynow.imaginit.com/peak/libraries/cc3ea5f2-0cb
 
 def _read_about_yaml(yaml_path):
     version = None
+    build = None
     authors = []
     try:
         with open(yaml_path, "r") as yaml_file:
@@ -26,20 +28,36 @@ def _read_about_yaml(yaml_path):
                 if stripped.startswith("toolbar_version:"):
                     version = stripped.split(":", 1)[1].strip()
                     continue
+                if stripped.startswith("build:"):
+                    build = stripped.split(":", 1)[1].strip()
+                    continue
                 if stripped.startswith("- "):
                     authors.append(stripped[2:].strip())
     except Exception:
         pass
-    return version, authors
+    return version, build, authors
 
 
-def _format_toolbar_version(value):
+def _normalize_build(value):
     text = str(value or "").strip()
     if not text:
-        return "Unknown"
-    if text.lower().startswith("v"):
+        return ""
+    if re.match(r"^\d{8}\+\d{4}$", text):
         return text
-    return "v{0}".format(text)
+    if re.match(r"^\d{12}$", text):
+        return "{0}+{1}".format(text[:8], text[8:])
+    return ""
+
+
+def _format_toolbar_version(version_value, build_value):
+    version_text = str(version_value or "").strip()
+    if not version_text:
+        return "Unknown"
+    version_text = version_text.lstrip("vV")
+    build_text = _normalize_build(build_value)
+    if build_text:
+        return "v{0}.{1}".format(version_text, build_text)
+    return "v{0}".format(version_text)
 
 
 def _get_pyrevit_version_text():
@@ -59,9 +77,9 @@ def _get_pyrevit_version_text():
 
 
 class AboutWindow(forms.WPFWindow):
-    def __init__(self, xaml_path, logo_path, toolbar_version, authors):
+    def __init__(self, xaml_path, logo_path, toolbar_version, build, authors):
         forms.WPFWindow.__init__(self, xaml_path)
-        self.toolbar_version_tb.Text = _format_toolbar_version(toolbar_version)
+        self.toolbar_version_tb.Text = _format_toolbar_version(toolbar_version, build)
         self.pyrevit_version_tb.Text = _get_pyrevit_version_text()
         self.authors_tb.Text = ", ".join(list(authors or [])) or "Not listed"
         if logo_path and os.path.exists(logo_path):
@@ -99,8 +117,8 @@ def main():
         forms.alert("Could not find AboutWindow.xaml.", title=TITLE, ok=True)
         return
 
-    toolbar_version, authors = _read_about_yaml(yaml_path)
-    dlg = AboutWindow(xaml_path, logo_path, toolbar_version, authors)
+    toolbar_version, build, authors = _read_about_yaml(yaml_path)
+    dlg = AboutWindow(xaml_path, logo_path, toolbar_version, build, authors)
     dlg.ShowDialog()
 
 

--- a/docs/changelog_automation_plan.md
+++ b/docs/changelog_automation_plan.md
@@ -1,0 +1,62 @@
+# Changelog Automation Plan (On Hold)
+
+## Status
+- State: On hold
+- Decision date: 2026-04-24
+- Active now: release/main PR labeling + manual version/build bump flow
+- Deferred: automatic changelog generation
+
+## Goal (Deferred)
+- Automatically build release notes from merged `develop` work.
+- Keep release notes consistent, concise, and traceable to PRs.
+- Group notes by:
+  - Highlights (top section)
+  - Tool (section per tool)
+  - Change entries under each tool in format:
+    - `<dev tag>` - Description ([#PR](link))
+
+## Proposed Label Model (Deferred)
+- Required exactly one on PRs into `develop`:
+  - `type: bug fix`
+  - `type: new feature`
+  - `type: enhancement`
+  - `type: deprecated`
+- Optional:
+  - `highlight`
+
+## Proposed Data Model (Deferred)
+- Keep one durable source file (no one-file-per-PR sprawl):
+  - `docs/changelog_index.json` (or `.jsonl`)
+- Each record keyed by PR number, with:
+  - PR number, title, URL
+  - merged timestamp
+  - type label
+  - highlight flag
+  - short description (from PR body or curated field)
+  - affected files
+  - inferred tool(s) from file path map (or explicit tool labels)
+
+## Proposed Rendered Outputs (Deferred)
+- `docs/changelog.md` for human browsing.
+- `release_notes.md` generated at release time from changelog index since last tag.
+
+## Proposed Workflow Integration (Deferred)
+1. On PR merge into `develop`, upsert one changelog record for that PR.
+2. Regenerate `docs/changelog.md` from index.
+3. Commit updated changelog artifacts.
+4. During release creation, generate release notes from records between last tag and current tag.
+
+## Open Decisions
+- Source of truth for description: PR body vs structured template section.
+- Tool mapping strategy: path rules vs explicit `tool:*` labels.
+- Release note window: tag-to-tag vs date window.
+- Edit model: fully automated vs maintainer review gate before publish.
+
+## Implementation Backlog (When Resumed)
+1. Create `.github/scripts/changelog.py` with commands:
+   - `record-pr`
+   - `render`
+2. Define label and PR template policy for `develop` PRs.
+3. Add/adjust workflow step(s) to call `record-pr` on merged PRs to `develop`.
+4. Add release workflow step to render `release_notes.md` from changelog index.
+5. Add tests for parser/render logic and idempotent re-runs.


### PR DESCRIPTION
• main PRs now require exactly one release label: release: major|minor|patch|none (case-insensitive).

• bump-version.yml PR validation is now main-only (no develop PR requirement).

• Manual bump (workflow_dispatch in Bump Toolbar Version + Build) is now effectively for main PRs.

• release: none is supported: version stays unchanged, build still bumps.

• Added new workflow to auto-bump build on every non-bot push to develop.

## Implications:
- PRs into develop are not blocked by release label/version checks.
- Pushes to develop will create a bot commit that bumps build (YYYYMMDD+hhmm).
- Main release PRs still need manual bump execution before merge.
- If a main PR release label changes after bump, rerun manual bump to satisfy validation.

## Team flow for PRs to main:

1. 	Open PR targeting main (typically develop -> main).
2. 	Apply exactly one label: release: major, release: minor, release: patch, or release: none.
3. 	Run workflow dispatch: Bump Toolbar Version + Build with that PR number.
4. 	Wait for bot metadata commit to land on the PR branch.
5. 	Confirm required checks pass:

- Enforce Release Label / enforce
- Bump Toolbar Version + Build / validate-release-metadata

8. Merge PR.