### PR TITLE
add installer UI and inline Content Collection warning

### DIFF
--- a/AE pyTools.extension/AE pyTools.Tab/CED Tools.panel/About.pushbutton/about.yaml
+++ b/AE pyTools.extension/AE pyTools.Tab/CED Tools.panel/About.pushbutton/about.yaml
@@ -1,5 +1,5 @@
 toolbar_version: 2.0.5
-build: 20260518+1354
+build: 20260518+1406
 authors:
 - Matt Gonzales
 - Anthony Evelina

--- a/msi/License.rtf
+++ b/msi/License.rtf
@@ -1,0 +1,20 @@
+{\rtf1\ansi\deff0{\fonttbl{\f0\fswiss\fcharset0 Arial;}}\fs22
+\b CED pyRevit Extensions Installer\b0\par
+\par
+This installer adds the following extensions to your pyRevit folder:\par
+\par
+- AE pyTools\par
+- CED ElecTools\par
+- CED MechTools\par
+- CEDLib (shared library)\par
+- CED Telemetry (local logging only)\par
+- WM Tools\par
+\par
+\b Install location: \b0 %APPDATA%\\pyRevit\\Extensions\par
+\par
+\b Telemetry: \b0 Remote telemetry disabled. All logs stay local.\par
+\par
+\b Legacy cleanup: \b0 Removes the obsolete H-E-B Tools.extension folder if present.\par
+\par
+No administrator rights required. Click \b I Accept \b0 to proceed with installation.\par
+}

--- a/msi/Product.wxs
+++ b/msi/Product.wxs
@@ -92,20 +92,21 @@
                  Before="CostFinalize"
                  Sequence="execute" />
 
-    <!-- ===== CED Content Collection warning ===== -->
-    <Binary Id="ContentCheckBin" SourceFile="ContentCheck.vbs" />
+    <!-- ===== CED Content Collection check (inline warning on Finish dialog if missing) ===== -->
+    <Property Id="CONTENTCOLLECTIONFOUND" Secure="yes">
+      <DirectorySearch Id="ContentCollectionDirSearch"
+                       Path="C:\ACC\ACCDocs\CoolSys\CED Content Collection" />
+    </Property>
 
-    <CustomAction Id="WarnIfNoContent"
-                  BinaryKey="ContentCheckBin"
-                  VBScriptCall="CheckContent"
-                  Execute="immediate"
-                  Return="ignore" />
+    <SetProperty Id="WIXUI_EXITDIALOGOPTIONALTEXT"
+                 Value="WARNING: CED Content Collection folder NOT FOUND at C:\ACC\ACCDocs\CoolSys\CED Content Collection. Please link the CED Content Collection to your Autodesk Docs before using the extensions."
+                 After="AppSearch">
+      NOT CONTENTCOLLECTIONFOUND
+    </SetProperty>
 
-    <InstallExecuteSequence>
-      <Custom Action="WarnIfNoContent" After="InstallFinalize">
-        NOT REMOVE
-      </Custom>
-    </InstallExecuteSequence>
+    <!-- ===== Installer UI (minimal wizard: Welcome+License -> Progress -> Finish) ===== -->
+    <UIRef Id="WixUI_Minimal" />
+    <WixVariable Id="WixUILicenseRtf" Value="License.rtf" />
 
   </Product>
 </Wix>

--- a/msi/build_msi.ps1
+++ b/msi/build_msi.ps1
@@ -54,7 +54,7 @@ if ($LASTEXITCODE -ne 0) { throw "heat.exe failed (exit $LASTEXITCODE)" }
 Push-Location $ScriptDir
 try {
     Write-Host "`n[3/4] Compiling .wxs -> .wixobj..." -ForegroundColor Yellow
-    & candle.exe -nologo -ext WixUtilExtension `
+    & candle.exe -nologo -ext WixUtilExtension -ext WixUIExtension `
         -dStagingDir="$StagingDir" `
         -dProductVersion="$Version" `
         "Product.wxs" "Extensions.wxs"
@@ -62,8 +62,9 @@ try {
 
     Write-Host "`n[4/4] Linking .wixobj -> .msi..." -ForegroundColor Yellow
     $OutputMsi = Join-Path $OutputDir "Updater_pyrevit.msi"
-    & light.exe -nologo -ext WixUtilExtension `
+    & light.exe -nologo -ext WixUtilExtension -ext WixUIExtension `
         -sw1076 -sice:ICE38 -sice:ICE43 -sice:ICE57 -sice:ICE61 -sice:ICE64 -sice:ICE91 `
+        -cultures:en-us `
         -out $OutputMsi `
         "Product.wixobj" "Extensions.wixobj"
     if ($LASTEXITCODE -ne 0) { throw "light.exe failed (exit $LASTEXITCODE)" }


### PR DESCRIPTION
Replaces the standalone VBScript MsgBox popup with WiX-native inline UI inside the installer window:

- Add WixUI_Minimal scheme (Welcome+License -> Progress -> Finish)
- License.rtf serves as a friendly installation-info page (what gets installed, where, telemetry behavior, legacy cleanup)
- Content Collection check now uses native DirectorySearch + SetProperty to populate WIXUI_EXITDIALOGOPTIONALTEXT, so any missing-folder warning renders on the Finish dialog instead of as a separate popup
- Add -ext WixUIExtension and -cultures:en-us to candle/light invocations

Note: msi/ContentCheck.vbs is no longer referenced and can be deleted in a follow-up PR. Kept in tree for now in case rollback is needed.